### PR TITLE
feature(flutter): NativebrikCrashReport for flutter

### DIFF
--- a/flutter/nativebrik_bridge/CHANGELOG.md
+++ b/flutter/nativebrik_bridge/CHANGELOG.md
@@ -51,3 +51,10 @@
 
 - Migrate event dispatch to dispatcher class: NativebrikDispatcher
 - Remove event dispatch from NativebrikBridge
+
+## 0.5.0
+
+- Update com.nativebrik.sdk to 0.2.2
+- Update Nativebrik to 0.6.2
+- Add NativebrikCrashReport
+- Fix Other Classes (No breaking changes)

--- a/flutter/nativebrik_bridge/android/build.gradle
+++ b/flutter/nativebrik_bridge/android/build.gradle
@@ -58,7 +58,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.nativebrik:sdk:0.2.1'
+        implementation 'com.nativebrik:sdk:0.2.2'
         implementation 'androidx.activity:activity-compose:1.8.2'
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'

--- a/flutter/nativebrik_bridge/android/src/main/kotlin/com/nativebrik/flutter/nativebrik_bridge/Manager.kt
+++ b/flutter/nativebrik_bridge/android/src/main/kotlin/com/nativebrik/flutter/nativebrik_bridge/Manager.kt
@@ -165,6 +165,15 @@ internal class NativebrikBridgeManager(private val binaryMessenger: BinaryMessen
     fun dispatch(name: String) {
         this.nativebrikClient?.experiment?.dispatch(NativebrikEvent(name))
     }
+
+    /**
+     * Records a crash with the given throwable.
+     *
+     * This method forwards the throwable to the Nativebrik SDK for crash reporting.
+     */
+    fun recordCrash(throwable: Throwable) {
+        this.nativebrikClient?.experiment?.record(throwable)
+    }
 }
 
 internal class OverlayViewFactory(private val manager: NativebrikBridgeManager): PlatformViewFactory(StandardMessageCodec.INSTANCE) {

--- a/flutter/nativebrik_bridge/android/src/main/kotlin/com/nativebrik/flutter/nativebrik_bridge/NativebrikBridgePlugin.kt
+++ b/flutter/nativebrik_bridge/android/src/main/kotlin/com/nativebrik/flutter/nativebrik_bridge/NativebrikBridgePlugin.kt
@@ -22,128 +22,204 @@ internal const val ON_EVENT_METHOD = "on-event"
 
 /** NativebrikBridgePlugin */
 class NativebrikBridgePlugin: FlutterPlugin, MethodCallHandler {
-  /// The MethodChannel that will the communication between Flutter and native Android
-  ///
-  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-  /// when the Flutter Engine is detached from the Activity
-  private lateinit var channel : MethodChannel
-  private lateinit var context: Context
-  private lateinit var manager: NativebrikBridgeManager
+    /// The MethodChannel that will the communication between Flutter and native Android
+    ///
+    /// This local reference serves to register the plugin with the Flutter Engine and unregister it
+    /// when the Flutter Engine is detached from the Activity
+    private lateinit var channel : MethodChannel
+    private lateinit var context: Context
+    private lateinit var manager: NativebrikBridgeManager
 
-  override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    val messenger = flutterPluginBinding.binaryMessenger
-    manager = NativebrikBridgeManager(messenger)
-    context = flutterPluginBinding.applicationContext
-    channel = MethodChannel(messenger, "nativebrik_bridge")
-    channel.setMethodCallHandler(this)
+    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        val messenger = flutterPluginBinding.binaryMessenger
+        manager = NativebrikBridgeManager(messenger)
+        context = flutterPluginBinding.applicationContext
+        channel = MethodChannel(messenger, "nativebrik_bridge")
+        channel.setMethodCallHandler(this)
 
-    flutterPluginBinding.platformViewRegistry.registerViewFactory(
-      OVERLAY_VIEW_ID,
-      OverlayViewFactory(manager)
-    )
-    flutterPluginBinding.platformViewRegistry.registerViewFactory(
-      EMBEDDING_VIEW_ID,
-      NativeViewFactory(manager)
-    )
-  }
+        flutterPluginBinding.platformViewRegistry.registerViewFactory(
+            OVERLAY_VIEW_ID,
+            OverlayViewFactory(manager)
+        )
+        flutterPluginBinding.platformViewRegistry.registerViewFactory(
+            EMBEDDING_VIEW_ID,
+            NativeViewFactory(manager)
+        )
+    }
 
-  @OptIn(DelicateCoroutinesApi::class)
-  override fun onMethodCall(call: MethodCall, result: Result) {
-    when (call.method) {
-        "getNativebrikSDKVersion" -> {
-          result.success(VERSION)
-        }
-        "connectClient" -> {
-          val projectId = call.arguments as String
-          if (projectId.isEmpty()) {
-            result.success("no")
-            return
-          }
-          val client = NativebrikClient(
-              Config(
-                  projectId,
-                  onEvent = { it ->
-                      this.channel.invokeMethod(ON_EVENT_METHOD, mapOf(
-                          "name" to it.name,
-                          "deepLink" to it.deepLink,
-                          "payload" to it.payload?.map { prop ->
-                              mapOf(
-                                  "name" to prop.name,
-                                  "value" to prop.value,
-                                  "type" to prop.type,
-                              )
-                          }
-                      ))
-                  }
-              ), context)
-          this.manager.setNativebrikClient(client)
-          result.success("ok")
-        }
-        "getUserId" -> {
-          val userId = this.manager.getUserId()
-          result.success(userId)
-        }
-        "setUserProperties" -> {
-          val properties = call.arguments as Map<String, String>
-          this.manager.setUserProperties(properties)
-          result.success("ok")
-        }
-        "getUserProperties" -> {
-          val properties = this.manager.getUserProperties()
-          result.success(properties)
-        }
-        "connectEmbedding" -> {
-          val channelId = call.argument<String>("channelId") as String
-          val id = call.argument<String>("id") as String
-          this.manager.connectEmbedding(channelId, id)
-          result.success("ok")
-        }
-        "disconnectEmbedding" -> {
-          val channelId = call.arguments as String
-          this.manager.disconnectEmbedding(channelId)
-          result.success("ok")
-        }
-        "connectRemoteConfig" -> {
-          val channelId = call.argument<String>("channelId") as String
-          val id = call.argument<String>("id") as String
-          GlobalScope.launch(Dispatchers.IO) {
-            manager.connectRemoteConfig(channelId, id).onSuccess {
-              result.success(it)
-            }.onFailure {
-              result.success("failed")
+    @OptIn(DelicateCoroutinesApi::class)
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        when (call.method) {
+            "getNativebrikSDKVersion" -> {
+                result.success(VERSION)
             }
-          }
-        }
-        "disconnectRemoteConfig" -> {
-          val channelId = call.arguments as String
-          this.manager.disconnectRemoteConfig(channelId)
-          result.success("ok")
-        }
-        "getRemoteConfigValue" -> {
-          val channelId = call.argument<String>("channelId") as String
-          val key = call.argument<String>("key") as String
-          val value = this.manager.getRemoteConfigValue(channelId, key)
-          result.success(value)
-        }
-        "connectEmbeddingInRemoteConfigValue" -> {
-          val channelId = call.argument<String>("channelId") as String
-          val embeddingChannelId = call.argument<String>("embeddingChannelId") as String
-          val key = call.argument<String>("key") as String
-          this.manager.connectEmbeddingInRemoteConfigValue(channelId, key, embeddingChannelId)
-          result.success("ok")
-        }
-        "dispatch" -> {
-          val event = call.arguments as String
-          this.manager.dispatch(event)
-          result.success("ok")
-        }
-        else -> {
-          result.notImplemented()
+            "connectClient" -> {
+                val projectId = call.arguments as String
+                if (projectId.isEmpty()) {
+                    result.success("no")
+                    return
+                }
+                val client = NativebrikClient(
+                    Config(
+                        projectId,
+                        onEvent = { it ->
+                            this.channel.invokeMethod(ON_EVENT_METHOD, mapOf(
+                                "name" to it.name,
+                                "deepLink" to it.deepLink,
+                                "payload" to it.payload?.map { prop ->
+                                    mapOf(
+                                        "name" to prop.name,
+                                        "value" to prop.value,
+                                        "type" to prop.type,
+                                    )
+                                }
+                            ))
+                        }
+                    ), context)
+                this.manager.setNativebrikClient(client)
+                result.success("ok")
+            }
+            "getUserId" -> {
+                val userId = this.manager.getUserId()
+                result.success(userId)
+            }
+            "setUserProperties" -> {
+                val properties = call.arguments as Map<String, String>
+                this.manager.setUserProperties(properties)
+                result.success("ok")
+            }
+            "getUserProperties" -> {
+                val properties = this.manager.getUserProperties()
+                result.success(properties)
+            }
+            "connectEmbedding" -> {
+                val channelId = call.argument<String>("channelId") as String
+                val id = call.argument<String>("id") as String
+                this.manager.connectEmbedding(channelId, id)
+                result.success("ok")
+            }
+            "disconnectEmbedding" -> {
+                val channelId = call.arguments as String
+                this.manager.disconnectEmbedding(channelId)
+                result.success("ok")
+            }
+            "connectRemoteConfig" -> {
+                val channelId = call.argument<String>("channelId") as String
+                val id = call.argument<String>("id") as String
+                GlobalScope.launch(Dispatchers.IO) {
+                    manager.connectRemoteConfig(channelId, id).onSuccess {
+                        result.success(it)
+                    }.onFailure {
+                        result.success("failed")
+                    }
+                }
+            }
+            "disconnectRemoteConfig" -> {
+                val channelId = call.arguments as String
+                this.manager.disconnectRemoteConfig(channelId)
+                result.success("ok")
+            }
+            "getRemoteConfigValue" -> {
+                val channelId = call.argument<String>("channelId") as String
+                val key = call.argument<String>("key") as String
+                val value = this.manager.getRemoteConfigValue(channelId, key)
+                result.success(value)
+            }
+            "connectEmbeddingInRemoteConfigValue" -> {
+                val channelId = call.argument<String>("channelId") as String
+                val embeddingChannelId = call.argument<String>("embeddingChannelId") as String
+                val key = call.argument<String>("key") as String
+                this.manager.connectEmbeddingInRemoteConfigValue(channelId, key, embeddingChannelId)
+                result.success("ok")
+            }
+            "dispatch" -> {
+                val event = call.arguments as String
+                this.manager.dispatch(event)
+                result.success("ok")
+            }
+            "recordCrash" -> {
+                try {
+                    val errorData = call.arguments as Map<*, *>
+                    val exception = errorData["exception"] as String
+                    val stackTrace = errorData["stack"] as String
+
+                    // Create a throwable with the Flutter error information
+                    val throwable = Throwable(exception).apply {
+                        this.stackTrace = parseStackTraceElements(stackTrace)
+                    }
+
+                    // Record the crash using the Nativebrik SDK
+                    this.manager.recordCrash(throwable)
+                    result.success("ok")
+                } catch (e: Exception) {
+                    result.error("CRASH_REPORT_ERROR", "Failed to record crash: ${e.message}", null)
+                }
+            }
+            else -> {
+                result.notImplemented()
+            }
         }
     }
-  }
 
-  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    channel.setMethodCallHandler(null)
-  }
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
+}
+
+// Helper method to parse Flutter stack trace into Java stack trace elements
+//
+// Flutter Stack Trace
+// #0      NativebrikDispatcher.dispatch (package:nativebrik_bridge/dispatcher.dart:10:5)
+// #1      _MyAppState.build.<anonymous closure> (package:nativebrik_bridge_example/main.dart:91:42)
+// ....
+//
+// Kotlin.StackTraceElement
+// StackTraceElement("NativebrikDispatcher", "dispatch", "package:nativebrik_bridge/dispatcher.dart", 10)
+// ...
+fun parseStackTraceElements(stackTraceString: String): Array<StackTraceElement> {
+    val lines = stackTraceString.split("\n")
+    return lines.mapNotNull { line ->
+        try {
+            // Simple parsing of Flutter stack trace format
+            // This is a basic implementation and might need to be enhanced
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) return@mapNotNull null
+
+            // Try to extract file, class, method and line information
+            val parts = trimmed.split(" ")
+            var fileInfo = parts.lastOrNull() ?: return@mapNotNull null
+            // this cannot handle generics methods if the generics is <anonymous closure>.
+            val methodPart = parts.takeLast(2).firstOrNull() ?: "unknown.unknown"
+
+            // Default values
+            var className = "unknown"
+            var methodName = "unknown"
+            var fileName = "unknown"
+            var lineNumber = -1
+
+            // Try to parse file and line information
+            if (fileInfo.contains(":")) {
+                fileInfo = fileInfo.substringAfter("(").substringBeforeLast(")")
+                val fileParts = fileInfo.split(":").map { it.trim() }
+                val packageName = fileParts.getOrNull(0) ?: "unknown"
+                val flutterFileName = fileParts.getOrNull(1) ?: "unknown"
+                fileName = "$packageName:$flutterFileName"
+                lineNumber = fileParts.getOrNull(2)?.toIntOrNull() ?: -1
+            }
+
+            // Try to extract method name if available
+            methodPart.let {
+                val lastDot = methodPart.indexOf(".")
+                if (lastDot > 0) {
+                    className = methodPart.substring(0, lastDot)
+                    methodName = methodPart.substring(lastDot + 1)
+                }
+            }
+
+            StackTraceElement(className, methodName, fileName, lineNumber)
+        } catch (e: Exception) {
+            // If parsing fails, create a generic stack trace element
+            StackTraceElement("flutter.Error", "unparseable", "flutter", -1)
+        }
+    }.toTypedArray()
 }

--- a/flutter/nativebrik_bridge/android/src/test/kotlin/com/nativebrik/flutter/nativebrik_bridge/NativebrikBridgePluginTest.kt
+++ b/flutter/nativebrik_bridge/android/src/test/kotlin/com/nativebrik/flutter/nativebrik_bridge/NativebrikBridgePluginTest.kt
@@ -1,5 +1,6 @@
 package com.nativebrik.flutter.nativebrik_bridge
 
+import kotlin.test.assertEquals
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import kotlin.test.Test
@@ -15,14 +16,34 @@ import com.nativebrik.sdk.VERSION
  */
 
 internal class NativebrikBridgePluginTest {
-  @Test
-  fun onMethodCall_getNativebrikSDKVersion_returnsExpectedValue() {
-    val plugin = NativebrikBridgePlugin()
+    @Test
+    fun onMethodCall_getNativebrikSDKVersion_returnsExpectedValue() {
+        val plugin = NativebrikBridgePlugin()
 
-    val call = MethodCall("getNativebrikSDKVersion", null)
-    val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
-    plugin.onMethodCall(call, mockResult)
+        val call = MethodCall("getNativebrikSDKVersion", null)
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
 
-    Mockito.verify(mockResult).success(VERSION)
-  }
+        Mockito.verify(mockResult).success(VERSION)
+    }
+
+    @Test
+    fun parseStackTraceElements_should_work() {
+        val stackTraces = parseStackTraceElements(
+            "#0      NativebrikDispatcher.dispatch (package:nativebrik_bridge/dispatcher.dart:10:5)\n" +
+            "#1      _MyAppState.build.<anonymous closure> (package:nativebrik_bridge_example/main.dart:91:42)"
+        )
+
+        val expected = listOf(
+            StackTraceElement("NativebrikDispatcher", "dispatch", "package:nativebrik_bridge/dispatcher.dart", 10),
+            StackTraceElement("unknown", "unknown", "package:nativebrik_bridge_example/main.dart", 91)
+        )
+
+        assertEquals(expected.size, stackTraces.size)
+        assertEquals(expected[0].fileName, stackTraces[0].fileName)
+        assertEquals(expected[0].lineNumber, stackTraces[0].lineNumber)
+        assertEquals(expected[1].fileName, stackTraces[1].fileName)
+        assertEquals(expected[1].lineNumber, stackTraces[1].lineNumber)
+    }
+
 }

--- a/flutter/nativebrik_bridge/e2e/ios/Podfile.lock
+++ b/flutter/nativebrik_bridge/e2e/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - Flutter (1.0.0)
-  - Nativebrik (0.6.1):
+  - Nativebrik (0.6.2):
     - YogaKit (~> 2.0.0)
   - nativebrik_bridge (0.0.1):
     - Flutter
-    - Nativebrik (~> 0.6.1)
+    - Nativebrik (~> 0.6.2)
   - Yoga (2.0.1)
   - YogaKit (2.0.1):
     - Yoga (~> 2.0.1)
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  Nativebrik: addd8f897045935d696c3a77d7b277724924844f
-  nativebrik_bridge: 75e46929985fc5d9b8253892eeda630f400390af
+  Nativebrik: adb35b9a1d24b918ff40043af7c5272e475c4bc2
+  nativebrik_bridge: c3562064da790c36c845f1cd817f6606dbba4860
   Yoga: 7ac7f65e2d7120bf97e75fd66436ed4c7bf8e37e
   YogaKit: 4751ba673fab49df29e2235e23c4ea7d6d5a339c
 

--- a/flutter/nativebrik_bridge/e2e/pubspec.lock
+++ b/flutter/nativebrik_bridge/e2e/pubspec.lock
@@ -137,7 +137,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   path:
     dependency: transitive
     description:

--- a/flutter/nativebrik_bridge/example/ios/Podfile.lock
+++ b/flutter/nativebrik_bridge/example/ios/Podfile.lock
@@ -2,11 +2,11 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - Nativebrik (0.6.1):
+  - Nativebrik (0.6.2):
     - YogaKit (~> 2.0.0)
   - nativebrik_bridge (0.0.1):
     - Flutter
-    - Nativebrik (~> 0.6.1)
+    - Nativebrik (~> 0.6.2)
   - Yoga (2.0.1)
   - YogaKit (2.0.1):
     - Yoga (~> 2.0.1)
@@ -33,8 +33,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 13825b8a9334a850581300559b8839134b124670
-  Nativebrik: addd8f897045935d696c3a77d7b277724924844f
-  nativebrik_bridge: 75e46929985fc5d9b8253892eeda630f400390af
+  Nativebrik: adb35b9a1d24b918ff40043af7c5272e475c4bc2
+  nativebrik_bridge: c3562064da790c36c845f1cd817f6606dbba4860
   Yoga: 7ac7f65e2d7120bf97e75fd66436ed4c7bf8e37e
   YogaKit: 4751ba673fab49df29e2235e23c4ea7d6d5a339c
 

--- a/flutter/nativebrik_bridge/example/lib/main.dart
+++ b/flutter/nativebrik_bridge/example/lib/main.dart
@@ -1,15 +1,23 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
-
 import 'package:nativebrik_bridge/nativebrik_bridge.dart';
-import 'package:nativebrik_bridge/embedding.dart';
-import 'package:nativebrik_bridge/remote_config.dart';
-import 'package:nativebrik_bridge/provider.dart';
-import 'package:nativebrik_bridge/user.dart';
-import 'package:nativebrik_bridge/dispatcher.dart';
 
 void main() {
-  runApp(const MyApp());
+  runZonedGuarded(() {
+    WidgetsFlutterBinding.ensureInitialized();
+    NativebrikBridge("cgv3p3223akg00fod19g");
+    FlutterError.onError = (errorDetails) {
+      NativebrikCrashReport.instance.recordFlutterError(errorDetails);
+    };
+    PlatformDispatcher.instance.onError = (error, stack) {
+      NativebrikCrashReport.instance.recordPlatformError(error, stack);
+      return true;
+    };
+    runApp(const MyApp());
+  }, (error, stack) {
+    NativebrikCrashReport.instance.recordPlatformError(error, stack);
+  });
 }
 
 class MyApp extends StatefulWidget {
@@ -20,7 +28,6 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final nativebrik = NativebrikBridge("cgv3p3223akg00fod19g");
   String _message = "Not Found";
   String _userId = "None";
   String _prefecture = "None";
@@ -37,10 +44,6 @@ class _MyAppState extends State<MyApp> {
     // message was in flight, we want to discard the reply rather than calling
     // setState to update our non-existent appearance.
     if (!mounted) return;
-
-    nativebrik.addEventListener((event) {
-      print("Nativebrik Global Embedding Event: $event");
-    });
 
     final user = NativebrikUser();
     var userId = await user.getId();

--- a/flutter/nativebrik_bridge/example/pubspec.lock
+++ b/flutter/nativebrik_bridge/example/pubspec.lock
@@ -160,7 +160,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   path:
     dependency: transitive
     description:

--- a/flutter/nativebrik_bridge/ios/Classes/Manager.swift
+++ b/flutter/nativebrik_bridge/ios/Classes/Manager.swift
@@ -54,7 +54,7 @@ class NativebrikBridgeManager {
         }
         nativebrikClient.user.setProperties(properties)
     }
-    
+
     func getUserProperties() -> [String: String]? {
         guard let nativebrikClient = self.nativebrikClient else {
             return nil
@@ -204,6 +204,18 @@ class NativebrikBridgeManager {
             return
         }
         nativebrikClient.experiment.dispatch(NativebrikEvent(name))
+    }
+
+    /**
+     * Records a crash with the given exception.
+     *
+     * This method forwards the exception to the Nativebrik SDK for crash reporting.
+     */
+    func recordCrash(exception: NSException) {
+        guard let nativebrikClient = self.nativebrikClient else {
+            return
+        }
+        nativebrikClient.experiment.record(exception: exception)
     }
 }
 

--- a/flutter/nativebrik_bridge/ios/nativebrik_bridge.podspec
+++ b/flutter/nativebrik_bridge/ios/nativebrik_bridge.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Nativebrik', '~> 0.6.1'
+  s.dependency 'Nativebrik', '~> 0.6.2'
   s.ios.deployment_target = '14.0'
   s.platform = :ios, '14.0'
 

--- a/flutter/nativebrik_bridge/lib/channel/nativebrik_bridge_method_channel.dart
+++ b/flutter/nativebrik_bridge/lib/channel/nativebrik_bridge_method_channel.dart
@@ -132,4 +132,12 @@ class MethodChannelNativebrikBridge extends NativebrikBridgePlatform {
     );
     return result;
   }
+
+  @override
+  Future<void> recordCrash(Map<String, dynamic> errorData) async {
+    await methodChannel.invokeMethod<void>(
+      'recordCrash',
+      errorData,
+    );
+  }
 }

--- a/flutter/nativebrik_bridge/lib/channel/nativebrik_bridge_platform_interface.dart
+++ b/flutter/nativebrik_bridge/lib/channel/nativebrik_bridge_platform_interface.dart
@@ -77,4 +77,12 @@ abstract class NativebrikBridgePlatform extends PlatformInterface {
   Future<String?> dispatch(String name) {
     throw UnimplementedError('dispatch() has not been implemented.');
   }
+
+  /// Records a crash with the given error data.
+  ///
+  /// This method sends the error data to the native implementation
+  /// for crash reporting.
+  Future<void> recordCrash(Map<String, dynamic> errorData) {
+    throw UnimplementedError('recordCrash() has not been implemented.');
+  }
 }

--- a/flutter/nativebrik_bridge/lib/crash_report.dart
+++ b/flutter/nativebrik_bridge/lib/crash_report.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/foundation.dart';
+import 'package:nativebrik_bridge/channel/nativebrik_bridge_platform_interface.dart';
+
+/// A class to handle crash reporting in Flutter applications.
+///
+/// This class provides methods to record Flutter errors and exceptions
+/// and sends them to the native Nativebrik SDK for tracking.
+///
+/// Usage:
+/// ```dart
+/// // Set up global error handling
+/// FlutterError.onError = (errorDetails) {
+///   NativebrikCrashReport.instance.recordFlutterError(errorDetails);
+/// };
+///
+/// // Set up platform dispatcher error handling
+/// PlatformDispatcher.instance.onError = (error, stack) {
+///   NativebrikCrashReport.instance.recordPlatformError(error, stack);
+///   return true;
+/// };
+/// ```
+class NativebrikCrashReport {
+  static final NativebrikCrashReport _instance = NativebrikCrashReport._();
+
+  /// The singleton instance of [NativebrikCrashReport].
+  static NativebrikCrashReport get instance => _instance;
+
+  NativebrikCrashReport._();
+
+  /// Creates a new instance of [NativebrikCrashReport].
+  ///
+  /// In most cases, you should use [NativebrikCrashReport.instance] instead.
+  factory NativebrikCrashReport() => _instance;
+
+  /// Records a Flutter error for crash reporting.
+  ///
+  /// This method takes a [FlutterErrorDetails] object, extracts the relevant
+  /// information, and sends it to the native implementation for tracking.
+  Future<void> recordFlutterError(FlutterErrorDetails errorDetails) async {
+    try {
+      final Map<String, dynamic> errorData = {
+        'exception': errorDetails.exception.toString(),
+        'stack': errorDetails.stack?.toString() ?? '',
+        'library': errorDetails.library ?? 'flutter',
+        'context': errorDetails.context?.toString() ?? '',
+        'summary': errorDetails.summary.toString(),
+      };
+
+      await NativebrikBridgePlatform.instance.recordCrash(errorData);
+    } catch (e) {
+      // Silently handle any errors in the crash reporting itself
+      // to avoid causing additional crashes
+      debugPrint('Error recording crash: $e');
+    }
+  }
+
+  /// Records a platform error and stack trace for crash reporting.
+  ///
+  /// This is a convenience method that can be used when you have an error
+  Future<void> recordPlatformError(Object error, StackTrace stackTrace) async {
+    try {
+      final Map<String, dynamic> errorData = {
+        'exception': error.toString(),
+        'stack': stackTrace.toString(),
+        'library': 'flutter',
+        'context': '',
+        'summary': error.toString(),
+      };
+
+      await NativebrikBridgePlatform.instance.recordCrash(errorData);
+    } catch (e) {
+      // Silently handle any errors in the crash reporting itself
+      debugPrint('Error recording crash: $e');
+    }
+  }
+}

--- a/flutter/nativebrik_bridge/lib/dispatcher.dart
+++ b/flutter/nativebrik_bridge/lib/dispatcher.dart
@@ -6,6 +6,18 @@ class NativebrikEvent {
 }
 
 class NativebrikDispatcher {
+  static final NativebrikDispatcher _instance = NativebrikDispatcher._();
+
+  /// The singleton instance of [NativebrikDispatcher].
+  static NativebrikDispatcher get instance => _instance;
+
+  NativebrikDispatcher._();
+
+  /// Creates a new instance of [NativebrikDispatcher].
+  ///
+  /// In most cases, you should use [NativebrikDispatcher.instance] instead.
+  factory NativebrikDispatcher() => _instance;
+
   Future<void> dispatch(NativebrikEvent event) {
     return NativebrikBridgePlatform.instance.dispatch(event.name);
   }

--- a/flutter/nativebrik_bridge/lib/nativebrik_bridge.dart
+++ b/flutter/nativebrik_bridge/lib/nativebrik_bridge.dart
@@ -3,6 +3,14 @@ import 'package:nativebrik_bridge/embedding.dart';
 import 'package:nativebrik_bridge/utils/parse_event.dart';
 import 'channel/nativebrik_bridge_platform_interface.dart';
 
+// Export public APIs
+export 'package:nativebrik_bridge/crash_report.dart';
+export 'package:nativebrik_bridge/dispatcher.dart';
+export 'package:nativebrik_bridge/embedding.dart';
+export 'package:nativebrik_bridge/provider.dart';
+export 'package:nativebrik_bridge/remote_config.dart';
+export 'package:nativebrik_bridge/user.dart';
+
 /// A bridge client to the nativebrik SDK.
 ///
 /// - Initialize the bridge with the project ID before using nativebrik SDK.

--- a/flutter/nativebrik_bridge/lib/nativebrik_bridge.dart
+++ b/flutter/nativebrik_bridge/lib/nativebrik_bridge.dart
@@ -16,8 +16,26 @@ export 'package:nativebrik_bridge/user.dart';
 /// - Initialize the bridge with the project ID before using nativebrik SDK.
 ///
 /// ```dart
-/// class _YourAppStore extends State<YourApp> {
-///   final nativebrik = NativebrikBridge("PROJECT ID");
+/// // Setup Nativebrik SDK
+/// void main() {
+///   runZonedGuarded(() {
+///     WidgetsFlutterBinding.ensureInitialized();
+///     // Initialize the bridge with the project ID
+///     NativebrikBridge("PROJECT ID");
+///     // Set up global error handling
+///     FlutterError.onError = (errorDetails) {
+///       NativebrikCrashReport.instance.recordFlutterError(errorDetails);
+///     };
+///     // Set up platform dispatcher error handling
+///     PlatformDispatcher.instance.onError = (error, stack) {
+///       NativebrikCrashReport.instance.recordPlatformError(error, stack);
+///       return true;
+///     };
+///     runApp(const YourApp());
+///   }, (error, stack) {
+///     // Record any unhandled errors
+///     NativebrikCrashReport.instance.recordPlatformError(error, stack);
+///   });
 /// }
 /// ```
 class NativebrikBridge {

--- a/flutter/nativebrik_bridge/lib/user.dart
+++ b/flutter/nativebrik_bridge/lib/user.dart
@@ -1,14 +1,54 @@
 import 'package:nativebrik_bridge/channel/nativebrik_bridge_platform_interface.dart';
 
+/// A class to handle NativebrikUser.
+///
+/// Usage:
+/// ```dart
+/// // Set Custom User Properties
+/// NativebrikUser.instance.setProperties({
+///   'prefecture': 'Tokyo',
+///   'environment': const bool.fromEnvironment('dart.vm.product')
+///       ? 'production'
+///       : 'development',
+/// });
+/// ```
 class NativebrikUser {
+  static final NativebrikUser _instance = NativebrikUser._();
+
+  /// The singleton instance of [NativebrikUser].
+  static NativebrikUser get instance => _instance;
+
+  /// Private constructor for singleton pattern.
+  NativebrikUser._();
+
+  /// Creates a new instance of [NativebrikUser].
+  ///
+  /// In most cases, you should use [NativebrikUser.instance] instead.
+  factory NativebrikUser() => _instance;
+
+  /// Retrieves the current user ID.
+  ///
+  /// Returns a [Future] that completes with the user ID as a [String],
+  /// or `null` if no user ID is set.
   Future<String?> getId() async {
     return await NativebrikBridgePlatform.instance.getUserId();
   }
 
+  /// Sets user properties for the current user.
+  ///
+  /// The [properties] parameter is a map of key-value pairs where both
+  /// keys and values are [String]s.
+  ///
+  /// Returns a [Future] that completes when the properties have been set.
   Future<void> setProperties(Map<String, String> properties) async {
     await NativebrikBridgePlatform.instance.setUserProperties(properties);
   }
 
+  /// Retrieves the current user's properties.
+  ///
+  /// Returns a [Future] that completes with a [Map] of user properties,
+  /// where both keys and values are [String]s. Returns `null` if no
+  /// properties are set or if the user is not identified.
   Future<Map<String, String>?> getProperties() async {
     return await NativebrikBridgePlatform.instance.getUserProperties();
   }

--- a/flutter/nativebrik_bridge/pubspec.yaml
+++ b/flutter/nativebrik_bridge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nativebrik_bridge
 description: "Nativebrik bridge sdk for flutter"
-version: 0.4.0
+version: 0.5.0
 homepage: "https://nativebrik.com"
 repository: "https://github.com/plaidev/nativebrik-sdk"
 


### PR DESCRIPTION
## Usage

```dart
void main() {
  runZonedGuarded(() {
    WidgetsFlutterBinding.ensureInitialized();
    NativebrikBridge("xxx");
    FlutterError.onError = (errorDetails) {
      NativebrikCrashReport.instance.recordFlutterError(errorDetails);
    };
    PlatformDispatcher.instance.onError = (error, stack) {
      NativebrikCrashReport.instance.recordPlatformError(error, stack);
      return true;
    };
    runApp(const YourApp());
  }, (error, stack) {
    NativebrikCrashReport.instance.recordPlatformError(error, stack);
  });
}
```

## Implementation

### 0. Supposing Flutter's StackTrace.String() is like

```
#0 NativebrikDispatcher.dispatch (package:nativebrik_bridge/dispathcer.dart:380:8)
#1 xxx.yyy (package:xxx/yyy:z:v)
#2 ...
```

### 1. Thus, Assuming that the error with a pattern "package:nativebrik_bridge/" should be NATIVEBRIK_SDK_ERROR.
So, Added that matching logic to the platform level sdks.

- iOS: https://github.com/plaidev/nativebrik-sdk/pull/89/files
- Android: https://github.com/plaidev/nativebrik-sdk/pull/91/files

### 2. Then, Added the two proxy methods to Flutter sdk.

``` dart
// 1. Handling Flutter Error
Future<void> recordFlutterError(FlutterErrorDetails errorDetails) async {
    try {
      final Map<String, dynamic> errorData = {
        'exception': errorDetails.exception.toString(),
        'stack': errorDetails.stack?.toString() ?? '',
        'library': errorDetails.library ?? 'flutter',
        'context': errorDetails.context?.toString() ?? '',
        'summary': errorDetails.summary.toString(),
      };

      await NativebrikBridgePlatform.instance.recordCrash(errorData);
    } catch (e) {
      // Silently handle any errors in the crash reporting itself
      // to avoid causing additional crashes
      debugPrint('Error recording crash: $e');
    }
  }

// 2. Handling Platform Error
Future<void> recordPlatformError(Object error, StackTrace stackTrace) async {
    try {
      final Map<String, dynamic> errorData = {
        'exception': error.toString(),
        'stack': stackTrace.toString(),
        'library': 'flutter',
        'context': '',
        'summary': error.toString(),
      };

      await NativebrikBridgePlatform.instance.recordCrash(errorData);
    } catch (e) {
      // Silently handle any errors in the crash reporting itself
      debugPrint('Error recording crash: $e');
    }
  }
```

### 3. Then, Added the same proxy to each platform level flutter libs,


 