### PR TITLE
chore: update Package.resolved format to version 3

### DIFF
--- a/ios/nativebrik.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/nativebrik.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,5 +11,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
## Summary
- Updated Swift Package Manager resolved file format from version 2 to 3
- This is an automatic format update made by Xcode 14+
- No functional changes

## Changes
- `version: 2` → `version: 3`
- Note: `originHash` field was already present in the file (not added in this change)

## Test plan
- [x] Verified Package.resolved is valid JSON
- [x] Dependency (ViewInspector 0.10.0) remains unchanged
- [ ] Build succeeds with updated format

🤖 Generated with [Claude Code](https://claude.ai/code)