### PR TITLE
refactor: concurrency

### DIFF
--- a/ios/Nativebrik/Nativebrik/component/action-listener.swift
+++ b/ios/Nativebrik/Nativebrik/component/action-listener.swift
@@ -163,15 +163,13 @@ func configureDisabled(target: UIView, context: UIBlockContext, requiredFields: 
     guard let requiredFields = requiredFields, !requiredFields.isEmpty else { return nil }
     let isDisabled = getIsDisabled(requiredFields: requiredFields)
     
-    let handleFormValueChange: FormValueListener = { values in
-        DispatchQueue.main.async {
-            if isDisabled(values) {
-                target.isUserInteractionEnabled = false
-                target.alpha = 0.5
-            } else {
-                target.isUserInteractionEnabled = true
-                target.alpha = 1.0
-            }
+    let handleFormValueChange: FormValueListener = { @MainActor values in
+        if isDisabled(values) {
+            target.isUserInteractionEnabled = false
+            target.alpha = 0.5
+        } else {
+            target.isUserInteractionEnabled = true
+            target.alpha = 1.0
         }
     }
     

--- a/ios/Nativebrik/Nativebrik/component/page.swift
+++ b/ios/Nativebrik/Nativebrik/component/page.swift
@@ -152,8 +152,10 @@ class PageView: UIView {
             )
 
             let assertion = dispatchedEvent.httpResponseAssertion
-            let handleEvent = { @MainActor () -> Void in
-                parentEventManager?.dispatch(event: dispatchedEvent)
+            let handleEvent = { () -> Void in
+                Task { @MainActor in
+                    parentEventManager?.dispatch(event: dispatchedEvent)
+                }
             }
             if let httpRequest = dispatchedEvent.httpRequest {
                 Task {

--- a/ios/Nativebrik/Nativebrik/component/page.swift
+++ b/ios/Nativebrik/Nativebrik/component/page.swift
@@ -152,10 +152,8 @@ class PageView: UIView {
             )
 
             let assertion = dispatchedEvent.httpResponseAssertion
-            let handleEvent = { () -> Void in
-                DispatchQueue.main.async {
-                    parentEventManager?.dispatch(event: dispatchedEvent)
-                }
+            let handleEvent = { @MainActor () -> Void in
+                parentEventManager?.dispatch(event: dispatchedEvent)
             }
             if let httpRequest = dispatchedEvent.httpRequest {
                 Task {

--- a/ios/Nativebrik/Nativebrik/component/renderer/collection.swift
+++ b/ios/Nativebrik/Nativebrik/component/renderer/collection.swift
@@ -178,8 +178,11 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
         
         if block.data?.kind == CollectionKind.CAROUSEL && block.data?.fullItemWidth == true && block.data?.autoScroll == true {
             let timeInterval = block.data?.autoScrollInterval ?? 3.0
-            DispatchQueue.main.async { [self] in
+            let setupTimer = { @MainActor [self] in
                 self.timer = Timer.scheduledTimer(timeInterval: TimeInterval(timeInterval), target: self, selector: #selector(automaticScroll), userInfo: nil, repeats: true)
+            }
+            Task {
+                await setupTimer()
             }
         }
         

--- a/ios/Nativebrik/Nativebrik/component/renderer/image.swift
+++ b/ios/Nativebrik/Nativebrik/component/renderer/image.swift
@@ -104,15 +104,13 @@ func loadAsyncImageToBackgroundSrc(url: String, view: UIView) {
         view.clipsToBounds = true
     }
     
-    nativebrikSession.dataTask(with: requestUrl) { (data, response, error) in
-        if error != nil {
-            return
-        }
-
-        DispatchQueue.main.async {
-            if let imageData = data {
+    Task {
+        do {
+            let (data, response) = try await nativebrikSession.data(from: requestUrl)
+            
+            await MainActor.run {
                 if isGif(response) {
-                    guard let image = UIImage.gifImageWithData(imageData) else {
+                    guard let image = UIImage.gifImageWithData(data) else {
                         return
                     }
                     UIView.transition(
@@ -124,7 +122,7 @@ func loadAsyncImageToBackgroundSrc(url: String, view: UIView) {
                             view.clipsToBounds = true
                         }
                 } else {
-                    guard let image = UIImage(data: imageData) else {
+                    guard let image = UIImage(data: data) else {
                         return
                     }
                     UIView.transition(
@@ -140,28 +138,30 @@ func loadAsyncImageToBackgroundSrc(url: String, view: UIView) {
                 }
                 view.layoutSubviews()
             }
+        } catch {
+            // Error handling - silently fail as before
+            return
         }
-    }.resume()
+    }
 }
 
 func loadAsyncImage(url: String, view: UIView, image: UIImageView) {
     guard let requestUrl = URL(string: url) else {
         return
     }
-    nativebrikSession.dataTask(with: requestUrl) { (data, response, error) in
-        DispatchQueue.main.async {
-            if error != nil {
-                return
-            }
+    
+    Task {
+        do {
+            let (data, response) = try await nativebrikSession.data(from: requestUrl)
             
-            if let imageData = data {
+            await MainActor.run {
                 if isGif(response) {
                     UIView.transition(
                         with: image,
                         duration: 0.2,
                         options: .transitionCrossDissolve,
                         animations: {
-                            image.image = UIImage.gifImageWithData(imageData)
+                            image.image = UIImage.gifImageWithData(data)
                         },
                         completion: nil)
                 } else {
@@ -170,16 +170,17 @@ func loadAsyncImage(url: String, view: UIView, image: UIImageView) {
                         duration: 0.2,
                         options: .transitionCrossDissolve,
                         animations: {
-                            image.image = UIImage(data: imageData)
+                            image.image = UIImage(data: data)
                         },
                         completion: nil)
                 }
                 view.layoutSubviews()
-            } else {
-                return
             }
+        } catch {
+            // Error handling - silently fail as before
+            return
         }
-    }.resume()
+    }
 }
 
 func isGif(_ response: URLResponse?) -> Boolean {

--- a/ios/Nativebrik/Nativebrik/data/track.swift
+++ b/ios/Nativebrik/Nativebrik/data/track.swift
@@ -106,13 +106,16 @@ class TrackRespositoryImpl: TrackRepository2 {
         self.queueLock.lock()
         if self.timer == nil {
             // here, use async not sync. main.sync will break the app.
-            DispatchQueue.main.async {
+            let setupTimer = { @MainActor in
                 self.timer?.invalidate()
                 self.timer = Timer.scheduledTimer(withTimeInterval: 4.0, repeats: true, block: { _ in
                     Task(priority: .low) {
                         try await self.sendAndFlush()
                     }
                 })
+            }
+            Task {
+                await setupTimer()
             }
         }
 

--- a/ios/Nativebrik/Nativebrik/remote-config.swift
+++ b/ios/Nativebrik/Nativebrik/remote-config.swift
@@ -205,15 +205,13 @@ class RemoteConfigSwiftViewModel: ObservableObject {
         let _ = RemoteConfig(
             experimentId: experimentId,
             container: container,
-            modalViewController: modalViewController) { phase in
-                DispatchQueue.main.async { [weak self] in
-                    switch phase {
-                    case .loading:
-                        return
-                    default:
-                        self?.phase = phase
-                        return
-                    }
+            modalViewController: modalViewController) { @MainActor [weak self] phase in
+                switch phase {
+                case .loading:
+                    return
+                default:
+                    self?.phase = phase
+                    return
                 }
             }
     }


### PR DESCRIPTION
GCD から Swift Concurrencyへの移行を行いました。

  ## 変更理由
  - モダンな非同期処理
  5.5以降の標準的な非同期処理パターンへの移行
  - コードの可読性向上
  async/awaitと@ MainActorによる、より直感的なコード
  - 将来性
  Swift 6への移行準備（Swift
  6では厳格な並行処理チェックが導入される）
 
  ### 主な変更パターン
  1. `DispatchQueue.main.async` → `@MainActor` クロージャ
  2. URLSession コールバック → `async/await` with `data(from:)`
  3. Timer設定の非同期処理 → `@MainActor` クロージャ

  ### 変更ファイル
  - **remote-config.swift**: フェーズ更新のコールバックを@MainActorに
  - **track.swift**: Timer初期化を@MainActorクロージャに
  - **image.swift**: ネットワーク処理を完全にasync/awaitに移行
  - **collection.swift**: 自動スクロールTimer設定を@MainActorに
  - **action-listener.swift**: フォーム値変更ハンドラを@MainActorに
  - **page.swift**: イベントディスパッチをTask + @MainActorに