### PR TITLE
refactor(flutter): improve state management in NativebrikAnchor

### DIFF
--- a/flutter/nativebrik_bridge/lib/anchor/anchor.dart
+++ b/flutter/nativebrik_bridge/lib/anchor/anchor.dart
@@ -59,9 +59,9 @@ class _AnchorState extends State<NativebrikAnchor> {
 
   @override
   void dispose() {
-    // Remove the key when the widget is disposed
-    _provider?.removeKey(widget.id);
     super.dispose();
+    // Remove the key when the widget is disposed
+    _provider?.removeKey(widget.id, childKey);
   }
 
   @override

--- a/flutter/nativebrik_bridge/lib/provider.dart
+++ b/flutter/nativebrik_bridge/lib/provider.dart
@@ -33,8 +33,11 @@ class NativebrikProviderState extends State<NativebrikProvider> {
   }
 
   /// Remove a global key by ID
-  void removeKey(String id) {
-    _keys.remove(id);
+  void removeKey(String id, GlobalKey key) {
+    final currentKey = _keys[id];
+    if (identical(currentKey, key)) {
+      _keys.remove(id);
+    }
   }
 
   @override


### PR DESCRIPTION
- Introduced a private _provider variable to manage the NativebrikProviderState.
- Updated initState and dispose methods to use the _provider for storing and removing keys, enhancing code clarity and reducing redundancy, fixing critical bugs.