### PR TITLE
chore(ios): remove Yoga and YogaKit from public products, add as internal dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .target(
             name: "Nativebrik",
-            path: "ios/Nativebrik/Nativebrik",
             dependencies: ["Yoga", "YogaKit"],
+            path: "ios/Nativebrik/Nativebrik",
             exclude: ["PrivacyInfo.xcprivacy"],
             resources: [
                 .copy("PrivacyInfo.xcprivacy")

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .target(
             name: "Nativebrik",
             path: "ios/Nativebrik/Nativebrik",
+            dependencies: ["Yoga", "YogaKit"],
             exclude: ["PrivacyInfo.xcprivacy"],
             resources: [
                 .copy("PrivacyInfo.xcprivacy")

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     products: [
         .library(
             name: "Nativebrik",
-            targets: ["Nativebrik", "Yoga", "YogaKit"]
+            targets: ["Nativebrik"]
         ),
     ],
     targets: [


### PR DESCRIPTION
## Summary
- Removed Yoga and YogaKit from the public library products
- Added Yoga and YogaKit as internal dependencies to the Nativebrik target

## Changes
1. Modified `Package.swift` to remove Yoga and YogaKit from the exposed library products array
2. Added Yoga and YogaKit as dependencies to the Nativebrik target for internal use

## Justification
This change encapsulates the Yoga layout engine as an internal implementation detail of the Nativebrik SDK rather than exposing it as a public API. This approach:
- Prevents direct consumer dependency on Yoga/YogaKit APIs
- Maintains better API boundaries and encapsulation
- Allows the SDK to change or update its layout engine implementation without breaking consumer code
- Reduces the public API surface area, making the SDK simpler to use and maintain

The Yoga components are now properly linked as internal dependencies while keeping them hidden from the public interface.

🤖 Generated with [Claude Code](https://claude.ai/code)