### PR TITLE
chore: update iOS test workflow configuration

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,26 +2,21 @@ name: "E2E Test"
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   publish-e2e-app:
-    runs-on: macos-13
+    runs-on: macos-26
     environment:
       name: Only Main
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '15.0'
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Build Nativebrik E2E
-        run: xcodebuild -workspace ./nativebrik.xcworkspace -scheme E2E -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.0.1' -derivedDataPath ./.dist
+        run: xcodebuild -workspace ./nativebrik.xcworkspace -scheme E2E -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0' -derivedDataPath ./.dist
       - name: Zip app
         run: |
           cd .dist/Build/Products/Release-iphonesimulator/ && zip -r E2E.app.zip ./E2E.app
-
       - name: Upload to MagicPod
         run: |
           curl --fail-with-body -L -X POST \

--- a/.github/workflows/test-ios.yaml
+++ b/.github/workflows/test-ios.yaml
@@ -2,11 +2,11 @@ name: Test
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
       - .github/workflows/e2e.yaml
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
       - .github/workflows/e2e.yaml
 
@@ -16,21 +16,17 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-14
+    runs-on: macos-26
     strategy:
       matrix:
-        scheme: [
-          Nativebrik
-        ]
-        destination: [
-          'platform=iOS Simulator,name=iPhone 15,OS=17.0.1'
-        ]
+        scheme: [Nativebrik]
+        destination: ["platform=iOS Simulator,name=iPhone 17,OS=26.0"]
     steps:
       - name: Install xcbeautify
         run: brew install xcbeautify
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '15.4'
+      # - uses: maxim-lobanov/setup-xcode@v1
+      #   with:
+      #     xcode-version: "15.4"
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/test-ios.yaml
+++ b/.github/workflows/test-ios.yaml
@@ -24,12 +24,8 @@ jobs:
     steps:
       - name: Install xcbeautify
         run: brew install xcbeautify
-      # - uses: maxim-lobanov/setup-xcode@v1
-      #   with:
-      #     xcode-version: "15.4"
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Test ${{ matrix.scheme }} on ${{ matrix.destination }}
         run: |
           xcodebuild test -scheme ${{ matrix.scheme }} -sdk iphonesimulator -destination '${{ matrix.destination }}' -skipMacroValidation -skipPackagePluginValidation | xcbeautify


### PR DESCRIPTION
Refactor the test workflow by adjusting branch specifications for consistency and updating the macOS version to 26. Additionally, modify the iOS Simulator destination to use the latest OS version. Comment out the Xcode setup step for potential future use.