### PR TITLE
chore: update SDK version to 0.12.0

### DIFF
--- a/Sources/Nativebrik/sdk.swift
+++ b/Sources/Nativebrik/sdk.swift
@@ -12,7 +12,7 @@ import Combine
 // for development
 public var nativebrikTrackUrl = "https://track.nativebrik.com/track/v1"
 public var nativebrikCdnUrl = "https://cdn.nativebrik.com"
-public let nativebrikSdkVersion = "0.11.1"
+public let nativebrikSdkVersion = "0.12.0"
 
 public let isNativebrikAvailable: Bool = {
     if #available(iOS 15.0, *) {


### PR DESCRIPTION
Bump the nativebrik SDK version from 0.11.1 to 0.12.0 to reflect the latest changes and improvements in the SDK.