### PR TITLE
Add 15-minute timeout to GitHub Actions workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish-e2e-app:
     runs-on: macos-26
+    timeout-minutes: 15
     environment:
       name: Only Main
     steps:

--- a/.github/workflows/test-ios.yaml
+++ b/.github/workflows/test-ios.yaml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   test:
     runs-on: macos-26
+    timeout-minutes: 15
     strategy:
       matrix:
         scheme: [Nativebrik]


### PR DESCRIPTION
## Summary
- Added `timeout-minutes: 15` to test workflow (test-ios.yaml)
- Added `timeout-minutes: 15` to E2E workflow (e2e.yaml)

This prevents jobs from running indefinitely in case of hangs or infinite loops.

## Test plan
- [ ] Verify workflows still run successfully
- [ ] Confirm timeout is properly enforced if a job hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)