### PR TITLE
Install missing iOS platform before release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,16 @@ jobs:
           xcodebuild -version
           swift --version
 
+      - name: Ensure iOS platform is installed for selected Xcode
+        run: |
+          if xcodebuild -showsdks | grep -q "iphoneos"; then
+            echo "iOS platform already installed."
+          else
+            echo "iOS platform missing for selected Xcode. Downloading..."
+            sudo xcodebuild -downloadPlatform iOS
+          fi
+          xcodebuild -showsdks
+
       - name: Validate version format
         run: |
           if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then


### PR DESCRIPTION
## Summary
- add a release workflow step to verify the selected Xcode has an iphoneos SDK
- download the iOS platform only when it is missing before make xcframework
- print installed SDKs after the check for easier runner diagnostics

## Why
The release job pins Xcode 16.0 and then archives an XCFramework slice for generic/platform=iOS. On some runners that Xcode installation does not include the iOS device platform, which causes xcodebuild to fail with an unable to find a destination error and an iOS 18.0 is not installed message.

## Validation
- git diff --check -- .github/workflows/release.yml
- reviewed Nubrick/create_xcframework.sh to confirm the build archives both device and simulator slices
