### PR TITLE
Fix XCFramework archive resolution

### DIFF
--- a/Nubrick/Nubrick.xcodeproj/xcshareddata/xcschemes/Nubrick.xcscheme
+++ b/Nubrick/Nubrick.xcodeproj/xcshareddata/xcschemes/Nubrick.xcscheme
@@ -13,15 +13,6 @@
             buildForProfiling = "YES"
             buildForArchiving = "YES"
             buildForAnalyzing = "YES">
-            <AutocreatedTestPlanReference>
-            </AutocreatedTestPlanReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "250554A22EA8ACFB005D8A1B"

--- a/Nubrick/create_xcframework.sh
+++ b/Nubrick/create_xcframework.sh
@@ -2,6 +2,7 @@
 set -e
 
 ROOT="$(pwd)"
+PROJECT_PATH="$ROOT/Nubrick.xcodeproj"
 BUILD_DIR="$ROOT/build"
 OUT_DIR="$ROOT/output"
 IOS_ARCHIVE="$BUILD_DIR/Nubrick-iOS.xcarchive"
@@ -12,6 +13,7 @@ mkdir -p "$BUILD_DIR" "$OUT_DIR"
 
 # Build for iOS
 xcodebuild archive \
+  -project "$PROJECT_PATH" \
   -scheme Nubrick \
   -configuration Release \
   -destination "generic/platform=iOS" \
@@ -21,6 +23,7 @@ xcodebuild archive \
 
 # Build for iOS Simulator
 xcodebuild archive \
+  -project "$PROJECT_PATH" \
   -scheme Nubrick \
   -configuration Release \
   -destination "generic/platform=iOS Simulator" \


### PR DESCRIPTION
Summary
- make the XCFramework archive script target Nubrick.xcodeproj explicitly for both device and simulator archives
- remove the empty build action entry from the shared Nubrick scheme so it only archives the framework target

Why
make xcframework relied on implicit Xcode project resolution inside Nubrick/create_xcframework.sh. On CI that could resolve the archive context incorrectly and surface misleading destination errors during the simulator archive step. The shared scheme also contained an empty build action entry, which is not needed and made the scheme configuration noisier than necessary.

Validation
- git diff --check -- Nubrick/create_xcframework.sh Nubrick/Nubrick.xcodeproj/xcshareddata/xcschemes/Nubrick.xcscheme
- locally verified the explicit xcodebuild archive -project ... -destination 'generic/platform=iOS Simulator' form resolves destinations correctly outside the failing implicit path
