### PR TITLE
Add release Xcode build diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,15 @@ jobs:
       - name: Install sentry-cli
         run: brew install sentry-cli
 
+      - name: Debug XCFramework build environment
+        run: |
+          echo "DEVELOPER_DIR=${DEVELOPER_DIR:-<unset>}"
+          xcode-select -p
+          which xcodebuild
+          xcodebuild -version
+          xcodebuild -showsdks
+          xcodebuild -showdestinations -project Nubrick/Nubrick.xcodeproj -scheme Nubrick
+
       - name: Build framework
         run: make xcframework
 

--- a/Nubrick/create_xcframework.sh
+++ b/Nubrick/create_xcframework.sh
@@ -8,6 +8,13 @@ OUT_DIR="$ROOT/output"
 IOS_ARCHIVE="$BUILD_DIR/Nubrick-iOS.xcarchive"
 SIM_ARCHIVE="$BUILD_DIR/Nubrick-iOS-Simulator.xcarchive"
 
+echo "DEVELOPER_DIR=${DEVELOPER_DIR:-<unset>}"
+xcode-select -p
+which xcodebuild
+xcodebuild -version
+xcodebuild -showsdks
+xcodebuild -showdestinations -project "$PROJECT_PATH" -scheme Nubrick
+
 rm -rf "$BUILD_DIR" "$OUT_DIR"
 mkdir -p "$BUILD_DIR" "$OUT_DIR"
 


### PR DESCRIPTION
Summary
- log the selected Xcode and SDK environment in the release workflow before make xcframework
- log the same Xcode environment inside the XCFramework build script
- print project-backed showdestinations output for the Nubrick scheme in both places

Why
The release job is still failing during XCFramework creation with misleading destination and SDK errors. This change adds enough diagnostic output to confirm which Xcode and SDKs are actually active when the script runs and how xcodebuild resolves destinations for the Nubrick scheme.

Validation
- git diff --check -- .github/workflows/release.yml Nubrick/create_xcframework.sh
