### PR TITLE
Use explicit SDKs for XCFramework archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,7 @@ jobs:
 
       - name: Ensure iOS platform is installed for selected Xcode
         run: |
-          if xcodebuild -showsdks | grep -q "iphoneos"; then
-            echo "iOS platform already installed."
-          else
-            echo "iOS platform missing for selected Xcode. Downloading..."
-            sudo xcodebuild -downloadPlatform iOS
-          fi
+          sudo xcodebuild -downloadPlatform iOS
           xcodebuild -showsdks
 
       - name: Validate version format

--- a/Nubrick/create_xcframework.sh
+++ b/Nubrick/create_xcframework.sh
@@ -23,7 +23,7 @@ xcodebuild archive \
   -project "$PROJECT_PATH" \
   -scheme Nubrick \
   -configuration Release \
-  -destination "generic/platform=iOS" \
+  -sdk iphoneos \
   -archivePath "$IOS_ARCHIVE" \
   SKIP_INSTALL=NO \
   BUILD_LIBRARY_FOR_DISTRIBUTION=YES 
@@ -33,7 +33,7 @@ xcodebuild archive \
   -project "$PROJECT_PATH" \
   -scheme Nubrick \
   -configuration Release \
-  -destination "generic/platform=iOS Simulator" \
+  -sdk iphonesimulator \
   -archivePath "$SIM_ARCHIVE" \
   SKIP_INSTALL=NO \
   BUILD_LIBRARY_FOR_DISTRIBUTION=YES


### PR DESCRIPTION
Summary
- replace generic iOS and iOS Simulator destinations with explicit iphoneos and iphonesimulator SDK selection in the XCFramework archive script

Why
The release workflow is selecting Xcode 16 correctly and the script confirms the matching iOS 18 SDKs are installed, but xcodebuild archive still fails when resolving generic destinations like generic/platform=iOS. Using explicit SDK selection avoids that destination resolver path while still producing the device and simulator framework slices needed for the XCFramework.
