### PR TITLE
Always install iOS platform in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,7 @@ jobs:
 
       - name: Ensure iOS platform is installed for selected Xcode
         run: |
-          if xcodebuild -showsdks | grep -q "iphoneos"; then
-            echo "iOS platform already installed."
-          else
-            echo "iOS platform missing for selected Xcode. Downloading..."
-            sudo xcodebuild -downloadPlatform iOS
-          fi
+          sudo xcodebuild -downloadPlatform iOS
           xcodebuild -showsdks
 
       - name: Validate version format


### PR DESCRIPTION
## Summary
- make the release workflow always run xcodebuild -downloadPlatform iOS after selecting Xcode 16
- keep the SDK listing afterward so the runner logs still show the installed platforms

## Why
See https://github.com/actions/runner-images/issues/12758
