### PR TITLE
Restore release setup and switch to Xcode 16.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,27 +48,13 @@ jobs:
       - name: Show available Xcodes
         run: ls /Applications
   
-      - name: Select Xcode 16.0 (compat baseline)
-        run: |
-          if [ -d "/Applications/Xcode_16.0.app/Contents/Developer" ]; then
-            sudo xcode-select -s "/Applications/Xcode_16.0.app/Contents/Developer"
-          elif [ -d "/Applications/Xcode_16.app/Contents/Developer" ]; then
-            sudo xcode-select -s "/Applications/Xcode_16.app/Contents/Developer"
-          else
-            echo "ERROR: Xcode 16.0 is not installed on this runner." >&2
-            ls -1 /Applications >&2
-            exit 1
-          fi
+      - name: Select Xcode 16.1
+        run: sudo xcode-select -s "/Applications/Xcode_16.1.app/Contents/Developer"
 
       - name: Confirm Xcode version
         run: |
           xcodebuild -version
           swift --version
-
-      - name: Ensure iOS platform is installed for selected Xcode
-        run: |
-          sudo xcodebuild -downloadPlatform iOS
-          xcodebuild -showsdks
 
       - name: Validate version format
         run: |
@@ -89,15 +75,6 @@ jobs:
 
       - name: Install sentry-cli
         run: brew install sentry-cli
-
-      - name: Debug XCFramework build environment
-        run: |
-          echo "DEVELOPER_DIR=${DEVELOPER_DIR:-<unset>}"
-          xcode-select -p
-          which xcodebuild
-          xcodebuild -version
-          xcodebuild -showsdks
-          xcodebuild -showdestinations -project Nubrick/Nubrick.xcodeproj -scheme Nubrick
 
       - name: Build framework
         run: make xcframework

--- a/Nubrick/create_xcframework.sh
+++ b/Nubrick/create_xcframework.sh
@@ -2,25 +2,16 @@
 set -e
 
 ROOT="$(pwd)"
-PROJECT_PATH="$ROOT/Nubrick.xcodeproj"
 BUILD_DIR="$ROOT/build"
 OUT_DIR="$ROOT/output"
 IOS_ARCHIVE="$BUILD_DIR/Nubrick-iOS.xcarchive"
 SIM_ARCHIVE="$BUILD_DIR/Nubrick-iOS-Simulator.xcarchive"
-
-echo "DEVELOPER_DIR=${DEVELOPER_DIR:-<unset>}"
-xcode-select -p
-which xcodebuild
-xcodebuild -version
-xcodebuild -showsdks
-xcodebuild -showdestinations -project "$PROJECT_PATH" -scheme Nubrick
 
 rm -rf "$BUILD_DIR" "$OUT_DIR"
 mkdir -p "$BUILD_DIR" "$OUT_DIR"
 
 # Build for iOS
 xcodebuild archive \
-  -project "$PROJECT_PATH" \
   -scheme Nubrick \
   -configuration Release \
   -destination "generic/platform=iOS" \
@@ -30,7 +21,6 @@ xcodebuild archive \
 
 # Build for iOS Simulator
 xcodebuild archive \
-  -project "$PROJECT_PATH" \
   -scheme Nubrick \
   -configuration Release \
   -destination "generic/platform=iOS Simulator" \


### PR DESCRIPTION
Summary
- restore the release workflow to the earlier simpler form and select Xcode 16.1 instead of 16.4
- restore the XCFramework build script to its original destination-based archive commands without the extra debug and project-path changes

Why
This reverts the later release-workflow and XCFramework script experiments and narrows the change back to the requested Xcode version update. The release job now matches the earlier setup more closely while using Xcode 16.1.

Validation
- git diff --check -- .github/workflows/release.yml Nubrick/create_xcframework.sh
