### PR TITLE
Add iOS platform download to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
           xcodebuild -version
           swift --version
 
+      - name: Ensure iOS platform is installed for selected Xcode
+        run: |
+          sudo xcodebuild -downloadPlatform iOS
+          xcodebuild -showsdks
+
       - name: Validate version format
         run: |
           if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then


### PR DESCRIPTION
Summary
- add a release workflow step that runs xcodebuild -downloadPlatform iOS after selecting Xcode 16.1
- keep xcodebuild -showsdks immediately after it so the installed SDKs are visible in the logs

Why
This reintroduces only the iOS platform download step into the current release workflow so the selected Xcode can fetch or verify the device platform before the XCFramework build starts.

Validation
- git diff --check -- .github/workflows/release.yml
