### PR TITLE
Refactor SDK API surface

### DIFF
--- a/Sources/Nubrick/Component/embedding.swift
+++ b/Sources/Nubrick/Component/embedding.swift
@@ -10,7 +10,7 @@ import UIKit
 import SwiftUI
 internal import YogaKit
 
-public enum EmbeddingPhase {
+public enum UIKitEmbeddingPhase {
     case loading
     case completed(UIView)
     case notFound
@@ -44,7 +44,7 @@ func convertEvent(_ event: UIBlockAction) -> ComponentEvent {
 }
 
 class EmbeddingUIView: UIView {
-    private let fallback: ((_ phase: EmbeddingPhase) -> UIView)
+    private let fallback: ((_ phase: UIKitEmbeddingPhase) -> UIView)
     private var fallbackView: UIView = UIView()
     
     @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(experimentId:componentId:renderContext:modalViewController:onEvent:fallback:onSizeChange:).")
@@ -58,7 +58,7 @@ class EmbeddingUIView: UIView {
         renderContext: RenderContext,
         modalViewController: ModalComponentViewController?,
         onEvent: ((_ event: ComponentEvent) -> Void)?,
-        fallback: ((_ phase: EmbeddingPhase) -> UIView)?,
+        fallback: ((_ phase: UIKitEmbeddingPhase) -> UIView)?,
         onSizeChange: ((_ width: CGFloat?, _ height: CGFloat?) -> Void)? = nil
     ) {
         self.fallback = fallback ?? { (_ phase) in
@@ -121,7 +121,7 @@ class EmbeddingUIView: UIView {
         self.yoga.applyLayout(preservingOrigin: true)
     }
 
-    func renderFallback(phase: EmbeddingPhase) {
+    func renderFallback(phase: UIKitEmbeddingPhase) {
         let view = self.fallback(phase)
         self.fallbackView.removeFromSuperview()
         self.addSubview(view)
@@ -134,7 +134,7 @@ class EmbeddingUIView: UIView {
     }
 }
 
-public struct ComponentView: View {
+struct ComponentView: View {
     @State private var width: CGFloat? = nil
     @State private var height: CGFloat? = nil
 
@@ -143,7 +143,7 @@ public struct ComponentView: View {
     let modalViewController: ModalComponentViewController?
     let onEvent: ((_ event: ComponentEvent) -> Void)?
 
-    public var body: some View {
+    var body: some View {
         RootViewRepresentable(
             root: root,
             renderContext: renderContext,
@@ -158,16 +158,16 @@ public struct ComponentView: View {
     }
 }
 
-public enum AsyncEmbeddingPhase {
+public enum SwiftUIEmbeddingPhase {
     case loading
-    case completed(ComponentView)
+    case completed(AnyView)
     case notFound
     case failed(Error)
 }
 
 @MainActor
 class EmbeddingSwiftViewModel: ObservableObject {
-    @Published var phase: AsyncEmbeddingPhase = .loading
+    @Published var phase: SwiftUIEmbeddingPhase = .loading
 
     func fetchEmbeddingAndUpdatePhase(
         experimentId: String,
@@ -184,11 +184,13 @@ class EmbeddingSwiftViewModel: ObservableObject {
                 case .success(let view):
                     switch view {
                     case .EUIRootBlock(let root):
-                        self?.phase = .completed(ComponentView(
-                            root: root,
-                            renderContext: renderContext,
-                            modalViewController: modalViewController,
-                            onEvent: onEvent
+                        self?.phase = .completed(AnyView(
+                            ComponentView(
+                                root: root,
+                                renderContext: renderContext,
+                                modalViewController: modalViewController,
+                                onEvent: onEvent
+                            )
                         ))
                     default:
                         self?.phase = .notFound
@@ -208,7 +210,7 @@ class EmbeddingSwiftViewModel: ObservableObject {
 }
 
 struct EmbeddingSwiftView: View {
-    @ViewBuilder private let _content: ((_ phase: AsyncEmbeddingPhase) -> AnyView)
+    @ViewBuilder private let _content: ((_ phase: SwiftUIEmbeddingPhase) -> AnyView)
     @ObservedObject private var data: EmbeddingSwiftViewModel
     
     init(
@@ -221,7 +223,7 @@ struct EmbeddingSwiftView: View {
         self._content = { phase in
             switch phase {
             case .completed(let component):
-                return AnyView(component)
+                return component
             case .loading:
                 return AnyView(ProgressView())
             default:
@@ -243,7 +245,7 @@ struct EmbeddingSwiftView: View {
         renderContext: RenderContext,
         modalViewController: ModalComponentViewController?,
         onEvent: ((_ event: ComponentEvent) -> Void)?,
-        content: @escaping ((_ phase: AsyncEmbeddingPhase) -> V)
+        content: @escaping ((_ phase: SwiftUIEmbeddingPhase) -> V)
     ) {
         self._content = { phase in
             AnyView(content(phase))
@@ -257,7 +259,7 @@ struct EmbeddingSwiftView: View {
         )
     }
 
-    public var body: some View {
+    var body: some View {
         self._content(data.phase)
     }
 }

--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -13,7 +13,7 @@ internal import YogaKit
 class ModalPageViewController: UIViewController {
     private var isFirstModal = false
     private let pageView: PageView?
-    public var backButtonBehaviorDelegate: ModalBackButtonBehaviorDelegate? = nil
+    var backButtonBehaviorDelegate: ModalBackButtonBehaviorDelegate? = nil
 
     @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(pageView:).")
     required init?(coder: NSCoder) {

--- a/Sources/Nubrick/Data/render-context.swift
+++ b/Sources/Nubrick/Data/render-context.swift
@@ -7,15 +7,6 @@
 
 import Foundation
 
-public enum NubrickError: Error {
-    case notFound
-    case failedToDecode
-    case unexpected
-    case skipRequest
-    case irregular(String)
-    case other(Error)
-}
-
 protocol RenderContext : Sendable {
     @MainActor
     func handleEvent(_ it: UIBlockAction)

--- a/Sources/Nubrick/Data/user.swift
+++ b/Sources/Nubrick/Data/user.swift
@@ -11,9 +11,9 @@ import UIKit
 typealias ExperimentHistoryRecord = TimeInterval
 
 struct UserProperty {
-    public let name: String
-    public let value: String
-    public let type: UserPropertyType
+    let name: String
+    let value: String
+    let type: UserPropertyType
 }
 
 enum NativebrikUserDefaultsKeys: String {
@@ -56,7 +56,7 @@ private let USER_SEED_KEY: String = "NATIVEBRIK_USER_SEED"
 private let USER_SEED_MAX: Int = 100000000
 
 @MainActor
-public class NubrickUser {
+class NubrickUser {
     private var properties: [String: String]
     private var customProperties: [String: String]
     private var lastBootTime: Double = getCurrentDate().timeIntervalSince1970
@@ -111,20 +111,20 @@ public class NubrickUser {
         self.comeBack()
     }
 
-    public var id: String {
+    var id: String {
         get {
             return self.properties[BuiltinUserProperty.userId.rawValue] ?? ""
         }
     }
 
-    public var retention: Int {
+    var retention: Int {
         get {
             return Int(self.properties[BuiltinUserProperty.retentionPeriod.rawValue] ?? "0") ?? 0
         }
     }
 
     // This is an alias of NubrickUser.setProperties
-    public func set(_ properties: [String: Any]) {
+    func set(_ properties: [String: Any]) {
         for (key, value) in properties {
             if key == BuiltinUserProperty.userId.rawValue {
                 // overwrite userId
@@ -139,11 +139,11 @@ public class NubrickUser {
         }
     }
 
-    public func setProperties(_ properties: [String: Any]) {
+    func setProperties(_ properties: [String: Any]) {
         self.set(properties)
     }
 
-    public func getProperties() -> [String:String] {
+    func getProperties() -> [String:String] {
         var props = self.customProperties
         props[BuiltinUserProperty.userId.rawValue] = self.properties[BuiltinUserProperty.userId.rawValue]
         return props
@@ -152,7 +152,7 @@ public class NubrickUser {
     /**
      print user properties for debug
      */
-    public func debugPrint() {
+    func debugPrint() {
         let props = self.toEventProperties(seed: 0)
         var dic: [String:String] = [:]
         for prop in props {
@@ -165,7 +165,7 @@ public class NubrickUser {
      This function updates the internal state that indicate how many times the user came back to the app / the time user was acitivated lastly.
      This function expects to be called when your app back to foreground from background.
      */
-    public func comeBack() {
+    func comeBack() {
         let now = getCurrentDate()
         let lastBootTime = getCurrentDate()
         self.properties[BuiltinUserProperty.lastBootTime.rawValue] = lastBootTime.ISO8601Format()

--- a/Sources/Nubrick/Schema/generated.swift
+++ b/Sources/Nubrick/Schema/generated.swift
@@ -391,7 +391,7 @@ struct TriggerSetting: Decodable, Encodable {
   var onTrigger: UIBlockAction?
   var trigger: TriggerEventDef?
 }
-indirect enum UIBlock: Decodable, Encodable, Sendable {
+indirect enum UIBlock: Decodable, Encodable {
   case EUIRootBlock(UIRootBlock)
   case EUIPageBlock(UIPageBlock)
   case EUIFlexContainerBlock(UIFlexContainerBlock)

--- a/Sources/Nubrick/_for_bridge.swift
+++ b/Sources/Nubrick/_for_bridge.swift
@@ -77,7 +77,7 @@ public enum NubrickBridge {
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
         onSizeChange: ((_ width: CGFloat?, _ height: CGFloat?) -> Void)? = nil,
-        content: @escaping (_ phase: EmbeddingPhase) -> UIView
+        content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView
     ) -> UIView {
         guard let runtime = NubrickSDK.requireRuntime() else {
             return UIView()

--- a/Sources/Nubrick/remote-config.swift
+++ b/Sources/Nubrick/remote-config.swift
@@ -102,7 +102,7 @@ public final class RemoteConfigVariant : Sendable {
         _ key: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        @ViewBuilder content: (@escaping (_ phase: AsyncEmbeddingPhase) -> V)
+        @ViewBuilder content: (@escaping (_ phase: SwiftUIEmbeddingPhase) -> V)
     ) -> some View {
         let componentId = self.get(key)
         return EmbeddingSwiftView(
@@ -140,7 +140,7 @@ public final class RemoteConfigVariant : Sendable {
         _ key: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        content: @escaping (_ phase: EmbeddingPhase) -> UIView
+        content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView
     ) -> UIView? {
         guard let componentId = self.get(key) else {
             return nil

--- a/Sources/Nubrick/scalars.swift
+++ b/Sources/Nubrick/scalars.swift
@@ -25,11 +25,11 @@ struct JSON: Decodable, @unchecked Sendable {
     init?(stringValue: String) { self.stringValue = stringValue }
   }
 
-  public init(value: Any) {
+  init(value: Any) {
     self.value = value
   }
 
-  public init(from decoder: Decoder) throws {
+  init(from decoder: Decoder) throws {
     if let container = try? decoder.container(keyedBy: CodingKeys.self) {
       var result = [String: Any]()
       try container.allKeys.forEach { (key) throws in
@@ -65,7 +65,7 @@ struct JSON: Decodable, @unchecked Sendable {
 }
 
 extension JSON: Encodable {
-  public func encode(to encoder: Encoder) throws {
+  func encode(to encoder: Encoder) throws {
     if let array = value as? [Any] {
       var container = encoder.unkeyedContainer()
       for value in array {
@@ -128,11 +128,11 @@ extension UIBlock: Hashable {
     return value
   }
 
-  public static func == (lhs: UIBlock, rhs: UIBlock) -> Bool {
+  static func == (lhs: UIBlock, rhs: UIBlock) -> Bool {
     return lhs.rawValue == rhs.rawValue
   }
 
-  public func hash(into hasher: inout Hasher) {
+  func hash(into hasher: inout Hasher) {
     hasher.combine(rawValue)
   }
 }

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -56,9 +56,9 @@ private final class AppMetrics: NSObject, MXMetricManagerSubscriber {
 }
 
 // Default backend endpoints (used unless overridden per client instance)
-public let nubrickTrackUrl = "https://track.nativebrik.com/track/v1"
-public let nubrickCdnUrl = "https://cdn.nativebrik.com"
-public let nubrickSdkVersion = "0.17.0"
+let nubrickTrackUrl = "https://track.nativebrik.com/track/v1"
+let nubrickCdnUrl = "https://cdn.nativebrik.com"
+let nubrickSdkVersion = "0.17.0"
 
 @MainActor
 private func openLink(_ event: ComponentEvent) {
@@ -130,6 +130,15 @@ public struct NubrickEvent: Sendable {
     }
 }
 
+public enum NubrickError: Error {
+    case notFound
+    case failedToDecode
+    case unexpected
+    case skipRequest
+    case irregular(String)
+    case other(Error)
+}
+
 public typealias NubrickArguments = [String: any Sendable]
 
 public typealias NubrickHttpRequestInterceptor = @Sendable (_ request: URLRequest) -> URLRequest
@@ -196,6 +205,22 @@ final class NubrickCore {
         }
     }
 
+    func setUserProperties(_ properties: [String: Any]) {
+        self.dependencies.user.setProperties(properties)
+    }
+
+    func setUserId(_ id: String) {
+        self.dependencies.user.set([BuiltinUserProperty.userId.rawValue: id])
+    }
+
+    func getUserId() -> String {
+        self.dependencies.user.id
+    }
+
+    func getUserProperties() -> [String: String] {
+        self.dependencies.user.getProperties()
+    }
+
     func appendTooltipExperimentHistory(experimentId: String) {
         guard !experimentId.isEmpty else { return }
         self.dependencies.databaseRepository.appendExperimentHistory(experimentId: experimentId)
@@ -244,7 +269,7 @@ final class NubrickCore {
         _ id: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        @ViewBuilder content: @escaping (_ phase: AsyncEmbeddingPhase) -> V
+        @ViewBuilder content: @escaping (_ phase: SwiftUIEmbeddingPhase) -> V
     ) -> some View {
         AnyView(EmbeddingSwiftView(
             experimentId: id,
@@ -274,7 +299,7 @@ final class NubrickCore {
         _ id: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        content: @escaping (_ phase: EmbeddingPhase) -> UIView
+        content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView
     ) -> UIView {
         EmbeddingUIView(
             experimentId: id,
@@ -314,7 +339,7 @@ final class NubrickCore {
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
         onSizeChange: ((_ width: CGFloat?, _ height: CGFloat?) -> Void)? = nil,
-        content: @escaping (_ phase: EmbeddingPhase) -> UIView
+        content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView
     ) -> UIView {
         EmbeddingUIView(
             experimentId: id,
@@ -470,7 +495,7 @@ public enum NubrickSDK {
         _ id: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        @ViewBuilder content: @escaping (_ phase: AsyncEmbeddingPhase) -> V
+        @ViewBuilder content: @escaping (_ phase: SwiftUIEmbeddingPhase) -> V
     ) -> some View {
         guard let runtime = requireRuntime() else {
             return AnyView(EmptyView())
@@ -495,7 +520,7 @@ public enum NubrickSDK {
         _ id: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        content: @escaping (_ phase: EmbeddingPhase) -> UIView
+        content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView
     ) -> UIView {
         guard let runtime = requireRuntime() else {
             return UIView()
@@ -550,6 +575,38 @@ public enum NubrickSDK {
     @available(*, deprecated, message: "NSException-based crash reporting has been replaced by MetricKit. This method no longer reports crashes. Crash reporting now happens automatically via MetricKit on iOS 14+.")
     public static func record(exception: NSException) {
         // No-op: MetricKit handles crash reporting automatically on iOS 14+
+    }
+
+    @MainActor
+    public static func setUserProperties(_ properties: [String: Any]) {
+        guard let runtime = requireRuntime() else {
+            return
+        }
+        runtime.setUserProperties(properties)
+    }
+
+    @MainActor
+    public static func setUserId(_ id: String) {
+        guard let runtime = requireRuntime() else {
+            return
+        }
+        runtime.setUserId(id)
+    }
+
+    @MainActor
+    public static func getUserId() -> String? {
+        guard let runtime = requireRuntime() else {
+            return nil
+        }
+        return runtime.getUserId()
+    }
+
+    @MainActor
+    public static func getUserProperties() -> [String: String] {
+        guard let runtime = requireRuntime() else {
+            return [:]
+        }
+        return runtime.getUserProperties()
     }
 }
 

--- a/Tests/NubrickTests/sdk.swift
+++ b/Tests/NubrickTests/sdk.swift
@@ -23,6 +23,30 @@ final class NubrickClientTests: XCTestCase {
             XCTAssertNoThrow(NubrickSDK.dispatch(NubrickEvent("Hello")))
         }
     }
+
+    @MainActor
+    func testUserPropertiesRoundTripThroughSDK() throws {
+        NubrickSDK.initialize(projectId: PROJECT_ID_FOR_TEST)
+
+        let originalUserId = NubrickSDK.getUserId() ?? ""
+        let testUserId = "sdk-user-id-test"
+        let testPropertyKey = "sdk_user_api_test_property"
+        let testPropertyValue = "sdk-user-api-value"
+
+        defer {
+            NubrickSDK.setUserId(originalUserId)
+            NubrickSDK.setUserProperties([testPropertyKey: ""])
+        }
+
+        NubrickSDK.setUserProperties([testPropertyKey: testPropertyValue])
+        NubrickSDK.setUserId(testUserId)
+
+        XCTAssertEqual(testUserId, NubrickSDK.getUserId())
+
+        let properties = NubrickSDK.getUserProperties()
+        XCTAssertEqual(testUserId, properties["userId"])
+        XCTAssertEqual(testPropertyValue, properties[testPropertyKey])
+    }
 }
 
 final class NubrickProviderTests: XCTestCase {


### PR DESCRIPTION
## What changed
- refactored the public embedding API surface by splitting the phase types into `SwiftUIEmbeddingPhase` and `UIKitEmbeddingPhase`
- moved `NubrickError` into the SDK entrypoint and narrowed several implementation-only symbols that no longer need to be public
- added SDK wrappers for reading and writing user ID and user properties

## Why
- the old embedding API mixed SwiftUI and UIKit concerns in a way that made the surface harder to reason about
- the new user-property accessors expose the intended SDK entrypoints directly instead of relying on lower-level types

## Validation
- `xcodebuild -scheme Example-Local -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -scheme NubrickTests -destination 'id=A9723CB2-C90E-46F7-AC25-033CEF5F8F90' -only-testing:NubrickTests/NubrickClientTests CODE_SIGNING_ALLOWED=NO`

## Impact
- this is an intentional breaking API change for consumers using the previous embedding phase types or other removed public symbols
- added test coverage for the new SDK user property getters and setters