### PR TITLE
Refresh bridge callback updates and user property helpers

### DIFF
--- a/Sources/Nubrick/Component/overlay.swift
+++ b/Sources/Nubrick/Component/overlay.swift
@@ -41,6 +41,16 @@ class OverlayViewController: UIViewController {
         self.triggerViewController.initialLoad()
     }
 
+    func updateCallbacks(
+        onDispatch: ((_ event: NubrickEvent) -> Void)?,
+        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+    ) {
+        self.triggerViewController.updateCallbacks(
+            onDispatch: onDispatch,
+            onTooltip: onTooltip
+        )
+    }
+
     @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(user:renderContext:onDispatch:onTooltip:).")
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/Sources/Nubrick/Component/trigger.swift
+++ b/Sources/Nubrick/Component/trigger.swift
@@ -43,6 +43,14 @@ class TriggerViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
+    func updateCallbacks(
+        onDispatch: ((_ event: NubrickEvent) -> Void)?,
+        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+    ) {
+        self.onDispatch = onDispatch
+        self.onTooltip = onTooltip
+    }
+
     func initialLoad() {
         self.didLoaded = true
 

--- a/Sources/Nubrick/Data/user.swift
+++ b/Sources/Nubrick/Data/user.swift
@@ -126,21 +126,29 @@ class NubrickUser {
     // This is an alias of NubrickUser.setProperties
     func set(_ properties: [String: Any]) {
         for (key, value) in properties {
-            if key == BuiltinUserProperty.userId.rawValue {
-                // overwrite userId
-                let strValue = String(describing: value)
-                self.properties[BuiltinUserProperty.userId.rawValue] = strValue
-                self.userDB.set(strValue, forKey: NativebrikUserDefaultsKeys.USER_ID.rawValue)
-                continue
-            }
-            let strValue = String(describing: value)
-            self.customProperties[key] = strValue
-            self.userDB.set(strValue, forKey: USER_CUSTOM_PROPERTY_KEY_PREFIX + key)
+            self.setProperty(key, value: value)
         }
     }
 
     func setProperties(_ properties: [String: Any]) {
         self.set(properties)
+    }
+
+    func setProperty(_ key: String, value: Any) {
+        if key == BuiltinUserProperty.userId.rawValue {
+            let strValue = String(describing: value)
+            self.properties[BuiltinUserProperty.userId.rawValue] = strValue
+            self.userDB.set(strValue, forKey: NativebrikUserDefaultsKeys.USER_ID.rawValue)
+            return
+        }
+
+        let strValue = String(describing: value)
+        self.customProperties[key] = strValue
+        self.userDB.set(strValue, forKey: USER_CUSTOM_PROPERTY_KEY_PREFIX + key)
+    }
+
+    func getProperty(_ key: String) -> String? {
+        self.getProperties()[key]
     }
 
     func getProperties() -> [String:String] {

--- a/Sources/Nubrick/_for_bridge.swift
+++ b/Sources/Nubrick/_for_bridge.swift
@@ -59,7 +59,7 @@ public enum NubrickBridge {
         trackCrashes: Bool = true,
         onTooltip: ((_ data: String, _ experimentId: String) -> Void)? = nil
     ) {
-        NubrickSDK.initializeInternal(
+        NubrickSDK.initializeBridge(
             projectId: projectId,
             onEvent: onEvent,
             httpRequestInterceptor: httpRequestInterceptor,

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -145,8 +145,18 @@ public typealias NubrickHttpRequestInterceptor = @Sendable (_ request: URLReques
 
 @MainActor
 final class NubrickCore {
+    @MainActor
+    private final class BridgeCallbackStore {
+        var onEvent: (@Sendable (_ event: ComponentEvent) -> Void)?
+
+        init(onEvent: (@Sendable (_ event: ComponentEvent) -> Void)?) {
+            self.onEvent = onEvent
+        }
+    }
+
     private let dependencies: NubrickDependencyContainer
     private let overlayVC: OverlayViewController
+    private let bridgeCallbackStore: BridgeCallbackStore
 
     init(
         projectId: String,
@@ -159,11 +169,12 @@ final class NubrickCore {
         onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
     ) {
         let user = NubrickUser()
+        let bridgeCallbackStore = BridgeCallbackStore(onEvent: onEvent)
         let actionHandler: UIBlockActionHandler = { action, _ in
             // Terminal sdk pipeline: convert -> side effects -> trigger dispatch.
             let converted = convertEvent(action)
             openLink(converted)
-            onEvent?(converted)
+            bridgeCallbackStore.onEvent?(converted)
 
             guard let name = converted.name,
                   !name.isEmpty else {
@@ -186,6 +197,7 @@ final class NubrickCore {
             httpRequestInterceptor: httpRequestInterceptor
         )
 
+        self.bridgeCallbackStore = bridgeCallbackStore
         self.dependencies = dependencies
         self.overlayVC = OverlayViewController(
             user: user,
@@ -199,6 +211,15 @@ final class NubrickCore {
         self.overlayVC.triggerViewController.dispatch(event: event)
     }
 
+    func updateBridgeCallbacks(
+        onEvent: (@Sendable (_ event: ComponentEvent) -> Void)?,
+        onDispatch: ((_ event: NubrickEvent) -> Void)?,
+        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+    ) {
+        self.bridgeCallbackStore.onEvent = onEvent
+        self.overlayVC.updateCallbacks(onDispatch: onDispatch, onTooltip: onTooltip)
+    }
+
     func sendFlutterCrash(_ crashEvent: TrackCrashEvent) {
         Task {
             await self.dependencies.trackRepository.sendFlutterCrash(crashEvent)
@@ -209,8 +230,16 @@ final class NubrickCore {
         self.dependencies.user.setProperties(properties)
     }
 
+    func setUserProperty(_ key: String, value: Any) {
+        self.dependencies.user.setProperty(key, value: value)
+    }
+
     func setUserId(_ id: String) {
-        self.dependencies.user.set([BuiltinUserProperty.userId.rawValue: id])
+        self.dependencies.user.setProperty(BuiltinUserProperty.userId.rawValue, value: id)
+    }
+
+    func getUserProperty(_ key: String) -> String? {
+        self.dependencies.user.getProperty(key)
     }
 
     func getUserId() -> String {
@@ -433,6 +462,41 @@ public enum NubrickSDK {
     }
 
     @MainActor
+    static func initializeBridge(
+        projectId: String,
+        onEvent: (@Sendable (_ event: ComponentEvent) -> Void)?,
+        httpRequestInterceptor: NubrickHttpRequestInterceptor?,
+        trackUrl: String?,
+        cdnUrl: String?,
+        cachePolicy: NubrickCachePolicy?,
+        onDispatch: ((_ event: NubrickEvent) -> Void)?,
+        trackCrashes: Bool,
+        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+    ) {
+        if let runtime {
+            runtime.updateBridgeCallbacks(
+                onEvent: onEvent,
+                onDispatch: onDispatch,
+                onTooltip: onTooltip
+            )
+            nubrickWarn("NubrickBridge.initialize(...) called more than once. Refreshed bridge callbacks on existing singleton.")
+            return
+        }
+
+        initializeInternal(
+            projectId: projectId,
+            onEvent: onEvent,
+            httpRequestInterceptor: httpRequestInterceptor,
+            trackUrl: trackUrl,
+            cdnUrl: cdnUrl,
+            cachePolicy: cachePolicy,
+            onDispatch: onDispatch,
+            trackCrashes: trackCrashes,
+            onTooltip: onTooltip
+        )
+    }
+
+    @MainActor
     public static func initialize(
         projectId: String,
         onEvent: (@Sendable (_ event: ComponentEvent) -> Void)? = nil,
@@ -586,11 +650,27 @@ public enum NubrickSDK {
     }
 
     @MainActor
+    public static func setUserProperty(_ key: String, value: Any) {
+        guard let runtime = requireRuntime() else {
+            return
+        }
+        runtime.setUserProperty(key, value: value)
+    }
+
+    @MainActor
     public static func setUserId(_ id: String) {
         guard let runtime = requireRuntime() else {
             return
         }
         runtime.setUserId(id)
+    }
+
+    @MainActor
+    public static func getUserProperty(_ key: String) -> String? {
+        guard let runtime = requireRuntime() else {
+            return nil
+        }
+        return runtime.getUserProperty(key)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- allow Flutter bridge re-initialize to refresh callbacks on the existing runtime
- ensure onEvent updates on re-initialize (not only onDispatch/onTooltip)
- add setUserProperty/getUserProperty and refactor setUserId through setProperty
- remove redundant @MainActor annotations on callback update methods

## Validation
- xcodebuild -workspace Nubrick.xcworkspace -scheme "Nubrick (Nubrick project)" -destination "generic/platform=iOS Simulator" build