### PR TITLE
Fix unused layout property and improve GIF detection robustness

### DIFF
--- a/Sources/Nubrick/Component/renderer/collection.swift
+++ b/Sources/Nubrick/Component/renderer/collection.swift
@@ -108,7 +108,6 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
     private var isReferenced: Bool = false
     private var data: [Any]? = nil
     private var gesture: ClickListener? = nil
-    private var layout: UICollectionViewFlowLayout? = nil
     private var pageControl: UIPageControl? = nil
     private var collectionView: UICollectionView? = nil
     
@@ -147,7 +146,6 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
         super.init(frame: .zero)
 
         let layout = getCollectionLayout(block)
-        self.layout = layout
         let root = UICollectionView(
             frame: CGRect(
                 x: 0,
@@ -326,9 +324,7 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let width = (self.block?.data?.fullItemWidth == true) ? self.frame.width : CGFloat(self.block?.data?.itemWidth ?? 0)
-        let size = CGSize(width: width, height: CGFloat(self.block?.data?.itemHeight ?? 0))
-        self.layout?.itemSize = size
-        return size
+        return CGSize(width: width, height: CGFloat(self.block?.data?.itemHeight ?? 0))
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {

--- a/Sources/Nubrick/Component/renderer/image.swift
+++ b/Sources/Nubrick/Component/renderer/image.swift
@@ -222,12 +222,19 @@ func loadAsyncImage(url: String, view: UIView, image: UIImageView) {
 }
 
 func isGif(_ response: URLResponse?) -> Boolean {
-    guard let response = response else {
+    guard let httpResponse = response as? HTTPURLResponse else {
         return false
     }
-    let contentType = (response as! HTTPURLResponse).allHeaderFields["Content-Type"] as? String
+
+    let contentType = httpResponse.allHeaderFields.first { key, _ in
+        guard let key = key as? String else {
+            return false
+        }
+        return key.caseInsensitiveCompare("Content-Type") == .orderedSame
+    }?.value as? String
+
     guard let contentType = contentType else {
         return false
     }
-    return contentType.hasSuffix("gif")
+    return contentType.lowercased().hasSuffix("gif")
 }


### PR DESCRIPTION
## Summary
- Remove unused `layout` property from `CollectionView` that was redundantly storing a reference and setting `itemSize` in the delegate method
- Fix potential crash in `isGif` by replacing force cast with safe optional binding
- Make HTTP header lookup case-insensitive per RFC 7230
- Make GIF content-type detection case-insensitive

## Test plan
- [ ] Verify collection views render correctly with proper item sizes
- [ ] Test GIF image loading with various server configurations (different header casing)
- [ ] Confirm no crashes when loading images with non-HTTP responses