### PR TITLE
Add NubrickSize type and onSizeChange callback to embedding APIs

### DIFF
--- a/Sources/Nubrick/Component/embedding.swift
+++ b/Sources/Nubrick/Component/embedding.swift
@@ -59,7 +59,7 @@ class EmbeddingUIView: UIView {
         modalViewController: ModalComponentViewController?,
         onEvent: ((_ event: ComponentEvent) -> Void)?,
         fallback: ((_ phase: UIKitEmbeddingPhase) -> UIView)?,
-        onSizeChange: ((_ width: CGFloat?, _ height: CGFloat?) -> Void)? = nil
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
         self.fallback = fallback ?? { (_ phase) in
             switch phase {
@@ -135,13 +135,32 @@ class EmbeddingUIView: UIView {
 }
 
 struct ComponentView: View {
-    @State private var width: CGFloat? = nil
-    @State private var height: CGFloat? = nil
+    @State private var width: NubrickSize = .fill
+    @State private var height: NubrickSize = .fill
 
     let root: UIRootBlock?
     let container: Container
     let modalViewController: ModalComponentViewController?
     let onEvent: ((_ event: ComponentEvent) -> Void)?
+    let onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
+
+    private var frameWidth: CGFloat? {
+        switch width {
+        case .fixed(let value):
+            return value
+        case .fill:
+            return nil
+        }
+    }
+
+    private var frameHeight: CGFloat? {
+        switch height {
+        case .fixed(let value):
+            return value
+        case .fill:
+            return nil
+        }
+    }
 
     var body: some View {
         RootViewRepresentable(
@@ -151,10 +170,11 @@ struct ComponentView: View {
             onEvent: { event in
                 onEvent?(convertEvent(event))
             },
-            width: $width, //pass for update
-            height: $height //pass for update
+            onSizeChange: onSizeChange,
+            width: $width,
+            height: $height
         )
-        .frame(width: width, height: height)
+        .frame(width: frameWidth, height: frameHeight)
     }
 }
 
@@ -174,11 +194,11 @@ class EmbeddingSwiftViewModel: ObservableObject {
         componentId: String? = nil,
         container: Container,
         modalViewController: ModalComponentViewController?,
-        onEvent: ((_ event: ComponentEvent) -> Void)?
+        onEvent: ((_ event: ComponentEvent) -> Void)?,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
         Task {
             let result = await container.fetchEmbedding(experimentId: experimentId, componentId: componentId)
-    
             await MainActor.run { [weak self] in
                 switch result {
                 case .success(let view):
@@ -189,7 +209,8 @@ class EmbeddingSwiftViewModel: ObservableObject {
                                 root: root,
                                 container: container,
                                 modalViewController: modalViewController,
-                                onEvent: onEvent
+                                onEvent: onEvent,
+                                onSizeChange: onSizeChange
                             )
                         ))
                     default:
@@ -218,7 +239,8 @@ struct EmbeddingSwiftView: View {
         componentId: String? = nil,
         container: Container,
         modalViewController: ModalComponentViewController?,
-        onEvent: ((_ event: ComponentEvent) -> Void)?
+        onEvent: ((_ event: ComponentEvent) -> Void)?,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
         self._content = { phase in
             switch phase {
@@ -235,7 +257,8 @@ struct EmbeddingSwiftView: View {
             experimentId: experimentId,
             container: container,
             modalViewController: modalViewController,
-            onEvent: onEvent
+            onEvent: onEvent,
+            onSizeChange: onSizeChange
         )
     }
 
@@ -245,7 +268,8 @@ struct EmbeddingSwiftView: View {
         container: Container,
         modalViewController: ModalComponentViewController?,
         onEvent: ((_ event: ComponentEvent) -> Void)?,
-        content: @escaping ((_ phase: SwiftUIEmbeddingPhase) -> V)
+        content: @escaping ((_ phase: SwiftUIEmbeddingPhase) -> V),
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
         self._content = { phase in
             AnyView(content(phase))
@@ -255,7 +279,8 @@ struct EmbeddingSwiftView: View {
             experimentId: experimentId,
             container: container,
             modalViewController: modalViewController,
-            onEvent: onEvent
+            onEvent: onEvent,
+            onSizeChange: onSizeChange
         )
     }
 

--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -178,16 +178,12 @@ final class PageView: UIView {
         self.configureLayout { layout in
             layout.isEnabled = true
             if self.page?.data?.kind == .COMPONENT {
-                if let height = self.page?.data?.frameHeight {
-                    if height != 0 {
-                        layout.height = YGValue(value: Float(height), unit: .point)
-                    }
+                if let height = self.page?.data?.frameHeight, height != 0 {
+                    layout.height = YGValue(value: Float(height), unit: .point)
                 }
 
-                if let width = self.page?.data?.frameWidth {
-                    if width != 0 {
-                        layout.width = YGValue(value: Float(width), unit: .point)
-                    }
+                if let width = self.page?.data?.frameWidth, width != 0 {
+                    layout.width = YGValue(value: Float(width), unit: .point)
                 }
             }
         }

--- a/Sources/Nubrick/Component/root.swift
+++ b/Sources/Nubrick/Component/root.swift
@@ -129,50 +129,58 @@ struct RootViewRepresentable: UIViewRepresentable {
     let container: Container
     let modalViewController: ModalComponentViewController?
     let onEvent: ((_ action: UIBlockAction) -> Void)?
-    @Binding var width: CGFloat?
-    @Binding var height: CGFloat?
+    let onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
+    @Binding var width: NubrickSize
+    @Binding var height: NubrickSize
 
     @MainActor
     final class SizeCoordinator {
-        private let w: Binding<CGFloat?>
-        private let h: Binding<CGFloat?>
+        private let w: Binding<NubrickSize>
+        private let h: Binding<NubrickSize>
+        var onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
         private var isActive = true
 
-        init(w: Binding<CGFloat?>, h: Binding<CGFloat?>) {
+        init(
+            w: Binding<NubrickSize>,
+            h: Binding<NubrickSize>,
+            onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
+        ) {
             self.w = w
             self.h = h
+            self.onSizeChange = onSizeChange
         }
 
         func deactivate() {
             isActive = false
         }
 
-        func report(width: CGFloat?, height: CGFloat?) {
-            Task { @MainActor [weak self] in
-                guard let self, self.isActive else { return }
-                self.w.wrappedValue = width
-                self.h.wrappedValue = height
-            }
+        func report(width: NubrickSize, height: NubrickSize) {
+            guard isActive else { return }
+            w.wrappedValue = width
+            h.wrappedValue = height
+            onSizeChange?(width, height)
         }
     }
 
     func makeCoordinator() -> SizeCoordinator {
-        SizeCoordinator(w: $width, h: $height)
+        SizeCoordinator(w: $width, h: $height, onSizeChange: onSizeChange)
     }
 
 
     func makeUIView(context: Self.Context) -> Self.UIViewType {
-        let onSizeChange : (CGFloat?, CGFloat?) -> Void = { [weak coordinator = context.coordinator] w, h in
-            coordinator?.report(width: w, height: h)
+        let onSizeChange: (NubrickSize, NubrickSize) -> Void = { [weak coordinator = context.coordinator] w, h in
+            Task { @MainActor in
+                coordinator?.report(width: w, height: h)
+            }
         }
         return RootView(
             root: root, container: container, modalViewController: modalViewController,
             onEvent: onEvent, onSizeChange: onSizeChange)
     }
 
-    // データの更新に応じてラップしている UIView を更新する
+    // Update the wrapped UIView when SwiftUI state changes.
     func updateUIView(_ uiView: Self.UIViewType, context: Self.Context) {
-
+        context.coordinator.onSizeChange = onSizeChange
     }
 
     static func dismantleUIView(_ uiView: Self.UIViewType, coordinator: SizeCoordinator) {
@@ -195,7 +203,7 @@ class RootView: UIView {
     private var modalViewController: ModalComponentViewController? = nil
     private let container: Container
     // callback to transmit size to SwiftUI
-    var onSizeChange: ((_ width: CGFloat?, _ height: CGFloat?) -> Void)?
+    var onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
 
     @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(root:container:modalViewController:onEvent:onNextTooltip:onDismiss:onSizeChange:).")
     required init?(coder: NSCoder) {
@@ -209,7 +217,7 @@ class RootView: UIView {
         onEvent: ((_ action: UIBlockAction) -> Void)?,
         onNextTooltip: ((_ pageId: String) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil,
-        onSizeChange: ((_ width: CGFloat?, _ height: CGFloat?) -> Void)? = nil
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
         self.id = root?.id ?? ""
         self.container = container
@@ -339,8 +347,10 @@ class RootView: UIView {
             )
         case .COMPONENT:
             // in case of embedding update size for swiftui
-            let width = page?.data?.frameWidth.map(CGFloat.init)
-            let height = page?.data?.frameHeight.map(CGFloat.init)
+            let frameWidth = page?.data?.frameWidth ?? 0
+            let frameHeight = page?.data?.frameHeight ?? 0
+            let width: NubrickSize = frameWidth == 0 ? .fill : .fixed(CGFloat(frameWidth))
+            let height: NubrickSize = frameHeight == 0 ? .fill : .fixed(CGFloat(frameHeight))
             self.onSizeChange?(width, height)
             fallthrough
         default:
@@ -369,9 +379,16 @@ class RootView: UIView {
         }
         switch page?.data?.kind {
         case .COMPONENT:
-            let width = page?.data?.frameWidth.map(CGFloat.init)
-            let height = page?.data?.frameHeight.map(CGFloat.init)
-            return CGSize(width: width ?? UIView.noIntrinsicMetric, height: height ?? UIView.noIntrinsicMetric)
+            let intrinsicWidth = page?.data?.frameWidth
+                .flatMap { $0 == 0 ? nil : CGFloat($0) }
+                ?? UIView.noIntrinsicMetric
+            let intrinsicHeight = page?.data?.frameHeight
+                .flatMap { $0 == 0 ? nil : CGFloat($0) }
+                ?? UIView.noIntrinsicMetric
+            return CGSize(
+                width: intrinsicWidth,
+                height: intrinsicHeight
+            )
         default:
             return super.intrinsicContentSize
         }

--- a/Sources/Nubrick/_for_bridge.swift
+++ b/Sources/Nubrick/_for_bridge.swift
@@ -70,7 +70,7 @@ public enum NubrickBridge {
         _ id: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        onSizeChange: ((_ width: CGFloat?, _ height: CGFloat?) -> Void)? = nil,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil,
         content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView
     ) -> UIView {
         guard let runtime = NubrickSDK.requireRuntime() else {

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -131,6 +131,11 @@ public typealias NubrickArguments = [String: any Sendable]
 
 public typealias NubrickHttpRequestInterceptor = @Sendable (_ request: URLRequest) -> URLRequest
 
+public enum NubrickSize: Sendable {
+    case fixed(CGFloat)
+    case fill
+}
+
 @MainActor
 final class NubrickCore {
     @MainActor
@@ -266,13 +271,15 @@ final class NubrickCore {
     func embedding(
         _ id: String,
         arguments: NubrickArguments? = nil,
-        onEvent: ((_ event: ComponentEvent) -> Void)? = nil
+        onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) -> some View {
         AnyView(EmbeddingSwiftView(
             experimentId: id,
             container: self.makeContainer(arguments: arguments),
             modalViewController: self.overlayVC.modalViewController,
-            onEvent: onEvent
+            onEvent: onEvent,
+            onSizeChange: onSizeChange
         ))
     }
 
@@ -280,7 +287,8 @@ final class NubrickCore {
         _ id: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        @ViewBuilder content: @escaping (_ phase: SwiftUIEmbeddingPhase) -> V
+        @ViewBuilder content: @escaping (_ phase: SwiftUIEmbeddingPhase) -> V,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) -> some View {
         AnyView(EmbeddingSwiftView(
             experimentId: id,
@@ -288,21 +296,24 @@ final class NubrickCore {
             container: self.makeContainer(arguments: arguments),
             modalViewController: self.overlayVC.modalViewController,
             onEvent: onEvent,
-            content: content
+            content: content,
+            onSizeChange: onSizeChange
         ))
     }
 
     func embeddingUIView(
         _ id: String,
         arguments: NubrickArguments? = nil,
-        onEvent: ((_ event: ComponentEvent) -> Void)? = nil
+        onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) -> UIView {
         EmbeddingUIView(
             experimentId: id,
             container: self.makeContainer(arguments: arguments),
             modalViewController: self.overlayVC.modalViewController,
             onEvent: onEvent,
-            fallback: nil
+            fallback: nil,
+            onSizeChange: onSizeChange
         )
     }
 
@@ -310,14 +321,16 @@ final class NubrickCore {
         _ id: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView
+        content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) -> UIView {
         EmbeddingUIView(
             experimentId: id,
             container: self.makeContainer(arguments: arguments),
             modalViewController: self.overlayVC.modalViewController,
             onEvent: onEvent,
-            fallback: content
+            fallback: content,
+            onSizeChange: onSizeChange
         )
     }
 
@@ -349,7 +362,7 @@ final class NubrickCore {
         _ id: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        onSizeChange: ((_ width: CGFloat?, _ height: CGFloat?) -> Void)? = nil,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil,
         content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView
     ) -> UIView {
         EmbeddingUIView(
@@ -530,12 +543,13 @@ public enum NubrickSDK {
     public static func embedding(
         _ id: String,
         arguments: NubrickArguments? = nil,
-        onEvent: ((_ event: ComponentEvent) -> Void)? = nil
+        onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) -> some View {
         guard let runtime = requireRuntime() else {
             return AnyView(EmptyView())
         }
-        return AnyView(runtime.embedding(id, arguments: arguments, onEvent: onEvent))
+        return AnyView(runtime.embedding(id, arguments: arguments, onEvent: onEvent, onSizeChange: onSizeChange))
     }
 
     @MainActor
@@ -543,24 +557,13 @@ public enum NubrickSDK {
         _ id: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        @ViewBuilder content: @escaping (_ phase: SwiftUIEmbeddingPhase) -> V
+        @ViewBuilder content: @escaping (_ phase: SwiftUIEmbeddingPhase) -> V,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) -> some View {
         guard let runtime = requireRuntime() else {
             return AnyView(content(.failed(runtimeUnavailableError())))
         }
-        return AnyView(runtime.embedding(id, arguments: arguments, onEvent: onEvent, content: content))
-    }
-
-    @MainActor
-    public static func embeddingUIView(
-        _ id: String,
-        arguments: NubrickArguments? = nil,
-        onEvent: ((_ event: ComponentEvent) -> Void)? = nil
-    ) -> UIView {
-        guard let runtime = requireRuntime() else {
-            return UIView()
-        }
-        return runtime.embeddingUIView(id, arguments: arguments, onEvent: onEvent)
+        return AnyView(runtime.embedding(id, arguments: arguments, onEvent: onEvent, content: content, onSizeChange: onSizeChange))
     }
 
     @MainActor
@@ -568,12 +571,26 @@ public enum NubrickSDK {
         _ id: String,
         arguments: NubrickArguments? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
-        content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
+    ) -> UIView {
+        guard let runtime = requireRuntime() else {
+            return UIView()
+        }
+        return runtime.embeddingUIView(id, arguments: arguments, onEvent: onEvent, onSizeChange: onSizeChange)
+    }
+
+    @MainActor
+    public static func embeddingUIView(
+        _ id: String,
+        arguments: NubrickArguments? = nil,
+        onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
+        content: @escaping (_ phase: UIKitEmbeddingPhase) -> UIView,
+        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) -> UIView {
         guard let runtime = requireRuntime() else {
             return content(.failed(runtimeUnavailableError()))
         }
-        return runtime.embeddingUIView(id, arguments: arguments, onEvent: onEvent, content: content)
+        return runtime.embeddingUIView(id, arguments: arguments, onEvent: onEvent, content: content, onSizeChange: onSizeChange)
     }
 
     public static func remoteConfig(

--- a/Tests/NubrickTests/Component/embedding.swift
+++ b/Tests/NubrickTests/Component/embedding.swift
@@ -6,6 +6,76 @@ let EMBEDDING_ID_1_FOR_TEST = "EMBEDDING_1"
 
 final class EmbeddingUIViewTests: XCTestCase {
     @MainActor
+    private func makeContainer(arguments: NubrickArguments? = nil) throws -> Container {
+        let db = try XCTUnwrap(createNativebrikCoreDataHelper(), "Could not init DB")
+        let user = NubrickUser()
+        let config = Config(projectId: PROJECT_ID_FOR_TEST)
+        let dependencies = NubrickDependencyContainer(
+            config: config,
+            user: user,
+            actionHandler: { _, _ in },
+            persistentContainer: db,
+            httpRequestInterceptor: nil
+        )
+        return dependencies.makeContainer(arguments: arguments)
+    }
+
+    private func makeComponentRoot(
+        pageId: String = "PAGE_1",
+        frameWidth: Int?,
+        frameHeight: Int?
+    ) -> UIRootBlock {
+        UIRootBlock(
+            id: "ROOT_1",
+            data: UIRootBlockData(
+                pages: [
+                    UIPageBlock(
+                        id: pageId,
+                        name: "Component",
+                        data: UIPageBlockData(
+                            kind: .COMPONENT,
+                            modalPresentationStyle: nil,
+                            modalScreenSize: nil,
+                            modalNavigationBackButton: nil,
+                            modalRespectSafeArea: nil,
+                            webviewUrl: nil,
+                            triggerSetting: nil,
+                            renderAs: nil,
+                            position: nil,
+                            httpRequest: nil,
+                            tooltipSize: nil,
+                            tooltipAnchor: nil,
+                            tooltipPlacement: nil,
+                            tooltipTransitionTarget: nil,
+                            props: nil,
+                            frameWidth: frameWidth,
+                            frameHeight: frameHeight,
+                            query: nil
+                        )
+                    )
+                ],
+                currentPageId: pageId
+            )
+        )
+    }
+
+    private func assertSize(
+        _ actual: NubrickSize,
+        equals expected: NubrickSize,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        switch (actual, expected) {
+        case (.fill, .fill):
+            XCTAssertTrue(true, file: file, line: line)
+        case let (.fixed(actualValue), .fixed(expectedValue)):
+            XCTAssertEqual(actualValue, expectedValue, file: file, line: line)
+        default:
+            XCTFail("Expected \(expected), got \(actual)", file: file, line: line)
+        }
+    }
+
+    @MainActor
     func testEmbeddingShouldFetch() {
         let expectation = expectation(description: "Fetch an embedding for test")
 
@@ -32,6 +102,142 @@ final class EmbeddingUIViewTests: XCTestCase {
             }
             XCTAssertTrue(didLoadingPhaseCome)
         }
+    }
+
+    @MainActor
+    func testEmbeddingOnSizeChange() {
+        let expectation = expectation(description: "onSizeChange should be called")
+
+        NubrickSDK.initialize(projectId: PROJECT_ID_FOR_TEST)
+        let view = NubrickSDK.embeddingUIView(
+            EMBEDDING_ID_1_FOR_TEST,
+            onEvent: nil,
+            content: { phase in
+                return UIView()
+            },
+            onSizeChange: { width, height in
+                expectation.fulfill()
+            }
+        )
+        withExtendedLifetime(view) {
+            waitForExpectations(timeout: 30) { error in
+                if let error = error {
+                    XCTFail("waitForExpectations(timeout:) failed: \(error)")
+                }
+            }
+        }
+    }
+
+    @MainActor
+    func testSizeCoordinatorUsesLatestOnSizeChangeCallback() {
+        var recordedWidth: NubrickSize = .fill
+        var recordedHeight: NubrickSize = .fill
+        let widthBinding = Binding<NubrickSize>(
+            get: { recordedWidth },
+            set: { recordedWidth = $0 }
+        )
+        let heightBinding = Binding<NubrickSize>(
+            get: { recordedHeight },
+            set: { recordedHeight = $0 }
+        )
+
+        var oldCallbackCalls = 0
+        var latestCallbackCalls = 0
+        let coordinator = RootViewRepresentable.SizeCoordinator(
+            w: widthBinding,
+            h: heightBinding,
+            onSizeChange: { _, _ in
+                oldCallbackCalls += 1
+            }
+        )
+        coordinator.onSizeChange = { width, height in
+            latestCallbackCalls += 1
+            self.assertSize(width, equals: .fill)
+            self.assertSize(height, equals: .fixed(240))
+        }
+
+        coordinator.report(width: .fill, height: .fixed(240))
+
+        XCTAssertEqual(oldCallbackCalls, 0)
+        XCTAssertEqual(latestCallbackCalls, 1)
+        assertSize(recordedWidth, equals: .fill)
+        assertSize(recordedHeight, equals: .fixed(240))
+    }
+
+    @MainActor
+    func testSizeCoordinatorDoesNotReportAfterDeactivation() {
+        var recordedWidth: NubrickSize = .fixed(120)
+        var recordedHeight: NubrickSize = .fixed(80)
+        let widthBinding = Binding<NubrickSize>(
+            get: { recordedWidth },
+            set: { recordedWidth = $0 }
+        )
+        let heightBinding = Binding<NubrickSize>(
+            get: { recordedHeight },
+            set: { recordedHeight = $0 }
+        )
+
+        var callbackCalls = 0
+        let coordinator = RootViewRepresentable.SizeCoordinator(
+            w: widthBinding,
+            h: heightBinding,
+            onSizeChange: { _, _ in
+                callbackCalls += 1
+            }
+        )
+
+        coordinator.deactivate()
+        coordinator.report(width: .fill, height: .fill)
+
+        XCTAssertEqual(callbackCalls, 0)
+        assertSize(recordedWidth, equals: .fixed(120))
+        assertSize(recordedHeight, equals: .fixed(80))
+    }
+
+    @MainActor
+    func testRootViewMapsComponentFramesToSizesAndIntrinsicMetrics() throws {
+        let expectation = expectation(description: "onSizeChange should be called")
+        var reportedWidth: NubrickSize?
+        var reportedHeight: NubrickSize?
+        let pageId = "COMPONENT_PAGE"
+        let rootView = RootView(
+            root: makeComponentRoot(pageId: pageId, frameWidth: 0, frameHeight: 280),
+            container: try makeContainer(),
+            modalViewController: nil,
+            onEvent: nil,
+            onSizeChange: { width, height in
+                reportedWidth = width
+                reportedHeight = height
+                expectation.fulfill()
+            }
+        )
+
+        rootView.presentPage(pageId: pageId, props: nil)
+
+        waitForExpectations(timeout: 1)
+        assertSize(try XCTUnwrap(reportedWidth), equals: .fill)
+        assertSize(try XCTUnwrap(reportedHeight), equals: .fixed(280))
+
+        let intrinsicSize = rootView.intrinsicContentSize
+        XCTAssertEqual(intrinsicSize.width, UIView.noIntrinsicMetric)
+        XCTAssertEqual(intrinsicSize.height, 280)
+    }
+
+    @MainActor
+    func testRootViewUsesIntrinsicMetricsForFixedComponentFrames() throws {
+        let pageId = "COMPONENT_PAGE_FIXED"
+        let rootView = RootView(
+            root: makeComponentRoot(pageId: pageId, frameWidth: 120, frameHeight: 80),
+            container: try makeContainer(),
+            modalViewController: nil,
+            onEvent: nil
+        )
+
+        rootView.presentPage(pageId: pageId, props: nil)
+
+        let intrinsicSize = rootView.intrinsicContentSize
+        XCTAssertEqual(intrinsicSize.width, 120)
+        XCTAssertEqual(intrinsicSize.height, 80)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Introduce `NubrickSize` enum (`.fixed(CGFloat)` / `.fill`) to replace raw `CGFloat?` in size callbacks, providing clearer semantics for fill-parent vs fixed-size layouts.
- Thread `onSizeChange` callback through all SwiftUI and UIKit embedding APIs (`NubrickSDK`, `NubrickCore`, `EmbeddingSwiftView`, `EmbeddingUIView`, `RootView`).
- Simplify nested conditionals in `PageView` layout configuration and update `intrinsicContentSize` to correctly treat zero-valued dimensions as no-intrinsic-metric.

## Test plan
- [ ] Verify embedding renders correctly with `.fill` (default) — should expand to fill parent
- [ ] Verify embedding renders correctly with `.fixed` values from server
- [ ] Confirm `onSizeChange` callback fires with correct `NubrickSize` values when component size updates
- [ ] Test UIKit embedding path (`embeddingUIView`) with `onSizeChange`
- [ ] Test SwiftUI embedding path (`embedding`) with `onSizeChange`
- [ ] Verify no regressions in modal/tooltip components