### PR TITLE
Add @frozen to public enums

### DIFF
--- a/Sources/Nubrick/Component/embedding.swift
+++ b/Sources/Nubrick/Component/embedding.swift
@@ -10,6 +10,7 @@ import UIKit
 import SwiftUI
 internal import YogaKit
 
+@frozen
 public enum UIKitEmbeddingPhase {
     case loading
     case completed(UIView)
@@ -178,6 +179,7 @@ struct ComponentView: View {
     }
 }
 
+@frozen
 public enum SwiftUIEmbeddingPhase {
     case loading
     case completed(AnyView)

--- a/Sources/Nubrick/remote-config.swift
+++ b/Sources/Nubrick/remote-config.swift
@@ -157,6 +157,7 @@ public final class RemoteConfigVariant : Sendable {
     }
 }
 
+@frozen
 public enum RemoteConfigPhase : Sendable {
     case loading
     case completed(RemoteConfigVariant)

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -92,6 +92,7 @@ final class Config : Sendable{
     }
 }
 
+@frozen
 public enum EventPropertyType: Sendable {
     case INTEGER
     case STRING
@@ -131,6 +132,7 @@ public typealias NubrickArguments = [String: any Sendable]
 
 public typealias NubrickHttpRequestInterceptor = @Sendable (_ request: URLRequest) -> URLRequest
 
+@frozen
 public enum NubrickSize: Sendable {
     case fixed(CGFloat)
     case fill


### PR DESCRIPTION
## Summary
- Mark public enums with `@frozen` to enable compiler optimizations for consumers since library evolution is enabled (`BUILD_LIBRARY_FOR_DISTRIBUTION = YES`)
- Applied to `UIKitEmbeddingPhase`, `SwiftUIEmbeddingPhase`, `RemoteConfigPhase`, `EventPropertyType`, and `NubrickSize`
- SPI-only enums like `CrashSeverity` are intentionally excluded as they are not switched on by consumers

## Test plan
- [ ] Verify the project builds successfully
- [ ] Confirm existing tests pass