### PR TITLE
Add deeplink test page to Example app

### DIFF
--- a/Examples/Example/Example.xcodeproj/project.pbxproj
+++ b/Examples/Example/Example.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		255EEE682EC56D2F0023413B /* Nubrick in Frameworks */ = {isa = PBXBuildFile; productRef = 255EEE672EC56D2F0023413B /* Nubrick */; };
+		AA0000012F0000000000001A /* DeeplinkPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000012F0000000000001B /* DeeplinkPageView.swift */; };
 		C13633C22AEB777800B9F437 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13633C12AEB777800B9F437 /* ExampleApp.swift */; };
 		C13633C42AEB777800B9F437 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13633C32AEB777800B9F437 /* ContentView.swift */; };
 		C13633C62AEB777900B9F437 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C13633C52AEB777900B9F437 /* Assets.xcassets */; };
@@ -48,6 +49,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		AA0000012F0000000000001B /* DeeplinkPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkPageView.swift; sourceTree = "<group>"; };
 		C13633BE2AEB777800B9F437 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C13633C12AEB777800B9F437 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
 		C13633C32AEB777800B9F437 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 				C13633C12AEB777800B9F437 /* ExampleApp.swift */,
 				F4377A6E2DED943B002EF91E /* Info.plist */,
 				C13633C32AEB777800B9F437 /* ContentView.swift */,
+				AA0000012F0000000000001B /* DeeplinkPageView.swift */,
 				C13633C52AEB777900B9F437 /* Assets.xcassets */,
 				C13633C72AEB777900B9F437 /* Preview Content */,
 			);
@@ -292,6 +295,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C13633C42AEB777800B9F437 /* ContentView.swift in Sources */,
+				AA0000012F0000000000001A /* DeeplinkPageView.swift in Sources */,
 				C13633C22AEB777800B9F437 /* ExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -477,7 +481,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.natvebrik.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -514,7 +518,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.natvebrik.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Examples/Example/Example.xcodeproj/project.pbxproj
+++ b/Examples/Example/Example.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		C13633D82AEB777900B9F437 /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C13633DC2AEB777900B9F437 /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
 		C13633DE2AEB777900B9F437 /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		F41628162FA0BC87006412B3 /* ExampleDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ExampleDebug.entitlements; sourceTree = "<group>"; };
 		F4377A6E2DED943B002EF91E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -118,6 +119,7 @@
 		C13633C02AEB777800B9F437 /* Example */ = {
 			isa = PBXGroup;
 			children = (
+				F41628162FA0BC87006412B3 /* ExampleDebug.entitlements */,
 				C13633C12AEB777800B9F437 /* ExampleApp.swift */,
 				F4377A6E2DED943B002EF91E /* Info.plist */,
 				C13633C32AEB777800B9F437 /* ContentView.swift */,
@@ -462,6 +464,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Example/ExampleDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -481,7 +484,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.10;
+				MARKETING_VERSION = 1.0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.natvebrik.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -518,7 +521,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.10;
+				MARKETING_VERSION = 1.0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.natvebrik.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Examples/Example/Example/DeeplinkPageView.swift
+++ b/Examples/Example/Example/DeeplinkPageView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct DeeplinkPageView: View {
+    let url: URL
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section("Received URL") {
+                    Text(url.absoluteString)
+                        .font(.system(.body, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+
+                Section("Components") {
+                    LabeledRow(label: "Scheme", value: url.scheme ?? "-")
+                    LabeledRow(label: "Host", value: url.host ?? "-")
+                    LabeledRow(label: "Path", value: url.path.isEmpty ? "/" : url.path)
+                }
+
+                if let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+                   !items.isEmpty {
+                    Section("Query Parameters") {
+                        ForEach(items, id: \.name) { item in
+                            LabeledRow(label: item.name, value: item.value ?? "(nil)")
+                        }
+                    }
+                }
+
+                Section("Test Links") {
+                    ForEach(Self.testLinks, id: \.label) { link in
+                        Button {
+                            if let testURL = URL(string: link.url) {
+                                UIApplication.shared.open(testURL)
+                            }
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(link.label)
+                                Text(link.url)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Deeplink")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private static let testLinks: [(label: String, url: String)] = [
+        ("Simple path", "nubrick-example://page/home"),
+        ("With query params", "nubrick-example://page/detail?id=123&ref=test"),
+        ("Campaign link", "nubrick-example://campaign?name=summer_sale&source=push"),
+    ]
+}
+
+private struct LabeledRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/Examples/Example/Example/ExampleApp.swift
+++ b/Examples/Example/Example/ExampleApp.swift
@@ -9,6 +9,10 @@ import Nubrick
 import SwiftUI
 import UIKit
 
+extension URL: @retroactive Identifiable {
+    public var id: String { absoluteString }
+}
+
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
         _ application: UIApplication,
@@ -22,6 +26,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 @MainActor
 struct ExampleApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @State private var deeplinkURL: URL?
 
     init() {
         guard let projectId = Bundle.main.object(forInfoDictionaryKey: "PROJECT_ID") as? String else {
@@ -37,6 +42,12 @@ struct ExampleApp: App {
         WindowGroup {
             NubrickProvider {
                 ContentView()
+            }
+            .onOpenURL { url in
+                deeplinkURL = url
+            }
+            .sheet(item: $deeplinkURL) { url in
+                DeeplinkPageView(url: url)
             }
         }
     }

--- a/Examples/Example/Example/ExampleDebug.entitlements
+++ b/Examples/Example/Example/ExampleDebug.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:eva.dev-nativebrik.com</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/Example/Example/Info.plist
+++ b/Examples/Example/Example/Info.plist
@@ -6,5 +6,16 @@
 	<false/>
 	<key>PROJECT_ID</key>
 	<string>$(PROJECT_ID)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.example.nubrick</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>nubrick-example</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Register `nubrick-example://` custom URL scheme in the Example app
- Add `DeeplinkPageView` that displays received URL, parsed components (scheme/host/path), query parameters, and built-in test links
- Wire up `onOpenURL` handler in `ExampleApp` to present the deeplink page as a sheet

## Test plan
- [ ] Build and run the Example app on a simulator
- [ ] Run `xcrun simctl openurl booted "nubrick-example://page/detail?id=123&ref=test"` and verify the deeplink sheet appears with parsed URL info
- [ ] Tap test links in the deeplink page and verify re-entry
- [ ] Configure a deeplink in the Nubrick dashboard and verify it triggers the page via TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)