### PR TITLE
Add Variable type and Sendable conformance to track types

### DIFF
--- a/Sources/Nubrick/Component/context.swift
+++ b/Sources/Nubrick/Component/context.swift
@@ -11,7 +11,7 @@ typealias UIBlockActionHandler = @MainActor (_ action: UIBlockAction, _ onHttpSe
 
 struct UIBlockContextInit {
     var container: Container? = nil
-    var variable: Any? = nil
+    var variable: Variable? = nil
     var childData: Any? = nil
     var properties: [Property]? = nil
     var actionHandler: UIBlockActionHandler? = nil
@@ -31,8 +31,7 @@ struct UIBlockContextChildInit {
 
 @MainActor
 class UIBlockContext {
-    // variable that page fetched with http request
-    private let variable: Any?
+    private let variable: Variable?
     // page properties
     private let properties: [Property]?
     private let container: Container?
@@ -70,7 +69,7 @@ class UIBlockContext {
             ))
     }
 
-    func getVariable() -> Any? {
+    func getVariable() -> Variable? {
         return self.variable
     }
 
@@ -126,7 +125,7 @@ class UIBlockContext {
     }
 
     func getByReferenceKey(key: String?) -> Any? {
-        return variableByPath(path: key ?? "", variable: self.variable)
+        return variableByPath(path: key ?? "", variable: self.variable?.value)
     }
 
     func getArrayByReferenceKey(key: String?) -> [Any]? {

--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -100,7 +100,7 @@ final class PageView: UIView {
     fileprivate let page: UIPageBlock?
     private let props: [Property]?
     private let container: Container
-    private var data: Any? = nil
+    private var data: Variable? = nil
     private var actionHandler: UIBlockActionHandler? = nil
     private var fullScreenInitialNavItemVisibility = false
     private var loading: Bool = false

--- a/Sources/Nubrick/Data/container.swift
+++ b/Sources/Nubrick/Data/container.swift
@@ -19,7 +19,7 @@ protocol Container : Sendable {
     @MainActor
     func makeContainer(arguments: NubrickArguments?) -> Container
     @MainActor
-    func createVariableForTemplate(data: Any?, properties: [Property]?) -> Any?
+    func createVariableForTemplate(data: Any?, properties: [Property]?) -> Variable?
     @MainActor
     func getFormValue(key: String) -> Any?
     @MainActor
@@ -31,7 +31,7 @@ protocol Container : Sendable {
     @MainActor
     func removeFormValueListener(_ id: String)
 
-    func sendHttpRequest(req: ApiHttpRequest, assertion: ApiHttpResponseAssertion?, variable: Any?) async -> Result<JSONData, NubrickError>
+    func sendHttpRequest(req: ApiHttpRequest, assertion: ApiHttpResponseAssertion?, variable: Variable?) async -> Result<JSONData, NubrickError>
     func fetchEmbedding(experimentId: String, componentId: String?) async -> Result<UIBlock, NubrickError>
     func fetchTriggerContent(trigger: String, kinds: [ExperimentKind]) async -> Result<(String, ExperimentKind?, UIBlock), NubrickError>
     func fetchRemoteConfig(experimentId: String) async -> Result<(String, ExperimentVariant), NubrickError>
@@ -94,7 +94,7 @@ final class ContainerImpl: Container {
     }
 
     @MainActor
-    func createVariableForTemplate(data: Any?, properties: [Property]?) -> Any? {
+    func createVariableForTemplate(data: Any?, properties: [Property]?) -> Variable? {
         return _createVariableForTemplate(
             user: self.user,
             data: data,
@@ -132,7 +132,7 @@ final class ContainerImpl: Container {
 
     // MARK: - HTTP Request
 
-    func sendHttpRequest(req: ApiHttpRequest, assertion: ApiHttpResponseAssertion?, variable: Any?) async -> Result<JSONData, NubrickError> {
+    func sendHttpRequest(req: ApiHttpRequest, assertion: ApiHttpResponseAssertion?, variable: Variable?) async -> Result<JSONData, NubrickError> {
         let request = ApiHttpRequest(
             url: compile(req.url ?? "", variable),
             method: req.method,

--- a/Sources/Nubrick/Data/track.swift
+++ b/Sources/Nubrick/Data/track.swift
@@ -54,7 +54,7 @@ private struct RawFrame: Decodable {
 }
 
 @_spi(FlutterBridge)
-public struct StackFrame: Encodable {
+public struct StackFrame: Encodable, Sendable {
     // iOS fields
     public let imageAddr: String?
     public let instructionAddr: String?
@@ -89,7 +89,7 @@ public struct StackFrame: Encodable {
 }
 
 @_spi(FlutterBridge)
-public struct ExceptionRecord: Encodable {
+public struct ExceptionRecord: Encodable, Sendable {
     public let type: String?
     public let message: String?
     public let callStacks: [StackFrame]?
@@ -106,7 +106,7 @@ public struct ExceptionRecord: Encodable {
 }
 
 @_spi(FlutterBridge)
-public struct TrackCrashEvent {
+public struct TrackCrashEvent: Sendable {
     public let exceptions: [ExceptionRecord]
     public let threads: [ThreadRecord]?
     public let platform: String?
@@ -130,7 +130,7 @@ public struct TrackCrashEvent {
 
 /// Severity level for crash/error reporting.
 @_spi(FlutterBridge)
-public enum CrashSeverity: String {
+public enum CrashSeverity: String, Sendable {
     case debug, info, warning, error, fatal
 
     /// Returns true if this severity level should be counted as an error (error or fatal).
@@ -185,7 +185,7 @@ struct TrackEvent: Encodable {
 }
 
 @_spi(FlutterBridge)
-public struct ThreadRecord: Encodable {
+public struct ThreadRecord: Encodable, Sendable {
     public let isMain: Bool?
     public let stacktrace: [StackFrame]?
 }

--- a/Sources/Nubrick/Data/variable.swift
+++ b/Sources/Nubrick/Data/variable.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+// All leaf values are JSON-primitive types (String, Int, Double, Bool, [Any], [String: Any])
+// which are inherently Sendable, but Swift can't prove that through [String: Any].
+struct Variable: @unchecked Sendable {
+    let value: [String: Any]
+}
+
 @MainActor
 func _createVariableForTemplate(
     user: NubrickUser? = nil,
@@ -15,7 +21,7 @@ func _createVariableForTemplate(
     form: [String: Any]? = nil,
     arguments: NubrickArguments? = nil,
     projectId: String? = nil
-) -> Any {
+) -> Variable {
     var userData: [String: Any] = [:]
     if let user = user {
         userData["id"] = user.id
@@ -35,28 +41,27 @@ func _createVariableForTemplate(
     let projectData: [String:Any] = [
         "id": projectId ?? "",
     ]
-    return [
+    return Variable(value: [
         "user": (userData.isEmpty ? nil : userData) as Any,
         "props": (propertiesData.isEmpty ? nil : propertiesData) as Any,
         "form": (formData?.isEmpty == true ? nil : formData) as Any,
         "args": arguments as Any,
         "data": data as Any,
         "project": projectData as Any,
-    ]
+    ])
 }
 
-func _mergeVariable(base: Any?, _ overlay: Any?) -> Any? {
-    guard let base = base as? [String:Any] else {
+func _mergeVariable(base: Variable?, _ overlay: Variable?) -> Variable? {
+    guard let base = base?.value else {
         return overlay
     }
-    let overlay = overlay as? [String:Any]
-    let data: [String:Any] = [
+    let overlay = overlay?.value
+    return Variable(value: [
         "user": overlay?["user"] ?? base["user"] as Any,
         "props": overlay?["props"] ?? base["props"] as Any,
         "form": overlay?["form"] ?? base["form"] as Any,
         "args": overlay?["args"] ?? base["args"] as Any,
         "data": overlay?["data"] ?? base["data"] as Any,
         "project": overlay?["project"] ?? base["project"] as Any,
-    ]
-    return data
+    ])
 }

--- a/Sources/Nubrick/Interpolation/compiler.swift
+++ b/Sources/Nubrick/Interpolation/compiler.swift
@@ -50,10 +50,11 @@ func hasPlaceholderPath(template: String) -> Bool {
     return regex.numberOfMatches(in: template, range: NSRange(location: 0, length: templateAsNsstring.length)) > 0
 }
 
-func compile(_ template: String, _ variable: Any?) -> String {
+func compile(_ template: String, _ variable: Variable?) -> String {
     guard let regex = placeholderRegex else {
         return template
     }
+    let raw = variable?.value
     var result = template as NSString
     for _ in 1...20 { // not to loop infinitly, limit to the 20 loops at maximum.
         // search the first matched {{palceholder}}, and replace it by a value.
@@ -68,8 +69,8 @@ func compile(_ template: String, _ variable: Any?) -> String {
         if placeholder.path == "" {
             break
         }
-        let value = variableByPath(path: placeholder.path, variable: variable)
-        
+        let value = variableByPath(path: placeholder.path, variable: raw)
+
         // format value when the placeholer is like {{ path | formatter }}
         let valueStr = formatValue(formatter: placeholder.formatter, value: value)
         result = result.replacingOccurrences(of: rawPlaceholder, with: valueStr) as NSString

--- a/Tests/NubrickTests/Interpolation/compiler.swift
+++ b/Tests/NubrickTests/Interpolation/compiler.swift
@@ -13,99 +13,99 @@ import XCTest
 final class CompileTemplateTests: XCTestCase {
     func testShouldCompileTemplate() throws {
         let template = "Hello {{ value }}"
-        let json: [String: Any] = [
+        let variable = Variable(value: [
             "value": "World",
-        ]
-        let result = compile(template, json)
+        ])
+        let result = compile(template, variable)
         XCTAssertEqual("Hello World", result)
     }
-    
+
     func testShouldCompileTemplateWithMultiplePlaceholders() throws {
         let template = "{{ value1 }} {{ value2 }}"
-        let json: [String: Any] = [
+        let variable = Variable(value: [
             "value1": "Hello",
             "value2": "World",
-        ]
-        let result = compile(template, json)
+        ])
+        let result = compile(template, variable)
         XCTAssertEqual("Hello World", result)
     }
-    
+
     func testShouldCompileTemplateWithoutFmtButPipelined() throws {
         let template = "Hello {{ value | }}"
-        let json: [String: Any] = [
+        let variable = Variable(value: [
             "value": "World"
-        ]
-        let result = compile(template, json)
+        ])
+        let result = compile(template, variable)
         XCTAssertEqual("Hello World", result)
     }
 
     func testShouldCompileTemplateWithUnknownFmt() throws {
         let template = "Hello {{ value | unknown }}"
-        let json: [String: Any] = [
+        let variable = Variable(value: [
             "value": "World"
-        ]
-        let result = compile(template, json)
+        ])
+        let result = compile(template, variable)
         XCTAssertEqual("Hello World", result)
     }
-    
+
     func testShouldCompileTemplateWithUpperFmt() throws {
-        let json: [String: Any] = [
+        let variable = Variable(value: [
             "value": "world"
-        ]
+        ])
         let template = "HELLO {{ value | upper }}"
-        let result = compile(template, json)
+        let result = compile(template, variable)
         XCTAssertEqual("HELLO WORLD", result)
     }
-    
+
     func testShouldCompileTemplateWithLowerFmt() throws {
-        let json: [String: Any] = [
+        let variable = Variable(value: [
             "value": "WORLD"
-        ]
+        ])
         let template = "hello {{ value | lower }}"
-        let result = compile(template, json)
+        let result = compile(template, variable)
         XCTAssertEqual("hello world", result)
     }
-    
+
     func testShouldCompileTemplateWithJsonFmt() throws {
-        let json: [String: Any] = [
+        let variable = Variable(value: [
             "value": ["Key": "Value"]
-        ]
+        ])
         let template = "{{ value | json }}"
-        let result = compile(template, json)
+        let result = compile(template, variable)
         XCTAssertEqual("{\"Key\":\"Value\"}", result)
     }
-    
+
     func testShouldCompileTemplateWithJsonFmtString() throws {
-        let json: [String: Any] = [
+        let variable = Variable(value: [
             "value": "hello"
-        ]
+        ])
         let template = "{{ value | json }}"
-        let result = compile(template, json)
+        let result = compile(template, variable)
         XCTAssertEqual("\"hello\"", result)
     }
-    
+
     func testShouldCompileTemplateWithJsonFmtNumber() throws {
-        let json: [String: Any] = [
+        let variable = Variable(value: [
             "value": 100
-        ]
+        ])
         let template = "{{ value | json }}"
-        let result = compile(template, json)
+        let result = compile(template, variable)
         XCTAssertEqual("100", result)
     }
-    
+
     func testShouldCompileTemplateWithJsonFmtNull() throws {
-        let json: [String: Any] = [
+        let variable = Variable(value: [
             "value": NSNull()
-        ]
+        ])
         let template = "{{ value | json }}"
-        let result = compile(template, json)
+        let result = compile(template, variable)
         XCTAssertEqual("null", result)
     }
-    
+
     func testShouldCompileTemplateWithJsonFmtNull2() throws {
-        let json: [String: Any] = [:]
+        let variable = Variable(value: [:])
         let template = "{{ value.test | json }}"
-        let result = compile(template, json)
+        let result = compile(template, variable)
         XCTAssertEqual("null", result)
     }
 }


### PR DESCRIPTION
## Summary
- Introduce a `Variable` struct wrapping `[String: Any]` with `@unchecked Sendable` to replace untyped `Any?` usage for template variables across `context.swift`, `page.swift`, `container.swift`, `variable.swift`, and `compiler.swift`
- Add `Sendable` conformance to `StackFrame`, `ExceptionRecord`, `TrackCrashEvent`, `CrashSeverity`, and `ThreadRecord` in `track.swift`

## Test plan
- [ ] Verify template variable interpolation works correctly in pages
- [ ] Verify HTTP request compilation with variable placeholders
- [ ] Verify form and property variable merging
- [ ] Confirm no concurrency warnings from track types