### PR TITLE
Move SDK initialization to AppDelegate in UIKit example

### DIFF
--- a/Examples/Example-UIKit/Example-UIKit/AppDelegate.swift
+++ b/Examples/Example-UIKit/Example-UIKit/AppDelegate.swift
@@ -6,13 +6,13 @@
 //
 
 import UIKit
+import Nubrick
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        
+        NubrickSDK.initialize(projectId: "cgv3p3223akg00fod19g")
         return true
     }
 

--- a/Examples/Example-UIKit/Example-UIKit/ViewController.swift
+++ b/Examples/Example-UIKit/Example-UIKit/ViewController.swift
@@ -14,8 +14,6 @@ final class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        NubrickSDK.initialize(projectId: "cgv3p3223akg00fod19g")
-
         // add Nativebrik.overlay at first
         let overlay = NubrickSDK.overlayViewController()
         self.addChild(overlay)


### PR DESCRIPTION
## Summary
- Move `NubrickSDK.initialize(projectId:)` from `ViewController.viewDidLoad()` to `AppDelegate.application(_:didFinishLaunchingWithOptions:)` in the UIKit example app
- Ensures SDK is initialized once at app launch before any UI is created, which is the recommended pattern

## Test plan
- [ ] Verify UIKit example app builds and runs correctly
- [ ] Confirm SDK initializes properly on app launch