### PR TITLE
Add standalone bridge callback update method

### DIFF
--- a/Sources/Nubrick/Component/trigger.swift
+++ b/Sources/Nubrick/Component/trigger.swift
@@ -47,8 +47,12 @@ class TriggerViewController: UIViewController {
         onDispatch: ((_ event: NubrickEvent) -> Void)?,
         onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
     ) {
-        self.onDispatch = onDispatch
-        self.onTooltip = onTooltip
+        if let onDispatch {
+            self.onDispatch = onDispatch
+        }
+        if let onTooltip {
+            self.onTooltip = onTooltip
+        }
     }
 
     func initialLoad() {

--- a/Sources/Nubrick/_for_bridge.swift
+++ b/Sources/Nubrick/_for_bridge.swift
@@ -66,6 +66,14 @@ public enum NubrickBridge {
         )
     }
 
+    public static func updateCallbacks(
+        onEvent: (@Sendable (_ event: ComponentEvent) -> Void)? = nil,
+        onDispatch: ((_ event: NubrickEvent) -> Void)? = nil,
+        onTooltip: ((_ data: String, _ experimentId: String) -> Void)? = nil
+    ) {
+        NubrickSDK.updateBridgeCallbacks(onEvent: onEvent, onDispatch: onDispatch, onTooltip: onTooltip)
+    }
+
     public static func embeddingForFlutterBridge(
         _ id: String,
         arguments: NubrickArguments? = nil,

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -205,7 +205,9 @@ final class NubrickCore {
         onDispatch: ((_ event: NubrickEvent) -> Void)?,
         onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
     ) {
-        self.bridgeCallbackStore.onEvent = onEvent
+        if let onEvent {
+            self.bridgeCallbackStore.onEvent = onEvent
+        }
         self.overlayVC.updateCallbacks(onDispatch: onDispatch, onTooltip: onTooltip)
     }
 
@@ -480,13 +482,8 @@ public enum NubrickSDK {
         trackCrashes: Bool,
         onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
     ) -> Bool {
-        if let runtime {
-            runtime.updateBridgeCallbacks(
-                onEvent: onEvent,
-                onDispatch: onDispatch,
-                onTooltip: onTooltip
-            )
-            nubrickWarn("NubrickBridge.initialize(...) called more than once. Refreshed bridge callbacks on existing singleton.")
+        if runtime != nil {
+            nubrickWarn("NubrickBridge.initialize(...) called more than once. Subsequent calls are ignored.")
             return true
         }
 
@@ -498,6 +495,16 @@ public enum NubrickSDK {
             trackCrashes: trackCrashes,
             onTooltip: onTooltip
         )
+    }
+
+    @MainActor
+    static func updateBridgeCallbacks(
+        onEvent: (@Sendable (_ event: ComponentEvent) -> Void)?,
+        onDispatch: ((_ event: NubrickEvent) -> Void)?,
+        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+    ) {
+        guard let runtime = requireRuntime() else { return }
+        runtime.updateBridgeCallbacks(onEvent: onEvent, onDispatch: onDispatch, onTooltip: onTooltip)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Add `NubrickBridge.updateCallbacks` to allow updating bridge callbacks independently from initialization
- Make `initializeBridge` truly idempotent — subsequent calls are now ignored instead of silently refreshing callbacks
- Nil parameters in `updateCallbacks` preserve existing callbacks instead of clearing them
- Use `requireRuntime()` in the update path so callers get a warning if the SDK isn't initialized