### PR TITLE
Add clearCallbacks to bridge and inline updateBridgeCallbacks

### DIFF
--- a/Sources/Nubrick/Component/overlay.swift
+++ b/Sources/Nubrick/Component/overlay.swift
@@ -51,6 +51,10 @@ class OverlayViewController: UIViewController {
         )
     }
 
+    func clearCallbacks() {
+        self.triggerViewController.clearCallbacks()
+    }
+
     @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(user:container:onDispatch:onTooltip:).")
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/Sources/Nubrick/Component/trigger.swift
+++ b/Sources/Nubrick/Component/trigger.swift
@@ -55,6 +55,11 @@ class TriggerViewController: UIViewController {
         }
     }
 
+    func clearCallbacks() {
+        self.onDispatch = nil
+        self.onTooltip = nil
+    }
+
     func initialLoad() {
         self.didLoaded = true
 

--- a/Sources/Nubrick/_for_bridge.swift
+++ b/Sources/Nubrick/_for_bridge.swift
@@ -71,7 +71,13 @@ public enum NubrickBridge {
         onDispatch: ((_ event: NubrickEvent) -> Void)? = nil,
         onTooltip: ((_ data: String, _ experimentId: String) -> Void)? = nil
     ) {
-        NubrickSDK.updateBridgeCallbacks(onEvent: onEvent, onDispatch: onDispatch, onTooltip: onTooltip)
+        guard let runtime = NubrickSDK.requireRuntime() else { return }
+        runtime.updateBridgeCallbacks(onEvent: onEvent, onDispatch: onDispatch, onTooltip: onTooltip)
+    }
+
+    public static func clearCallbacks() {
+        guard let runtime = NubrickSDK.requireRuntime() else { return }
+        runtime.clearBridgeCallbacks()
     }
 
     public static func embeddingForFlutterBridge(

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -211,6 +211,11 @@ final class NubrickCore {
         self.overlayVC.updateCallbacks(onDispatch: onDispatch, onTooltip: onTooltip)
     }
 
+    func clearBridgeCallbacks() {
+        self.bridgeCallbackStore.onEvent = nil
+        self.overlayVC.clearCallbacks()
+    }
+
     func sendFlutterCrash(_ crashEvent: TrackCrashEvent) {
         Task {
             await self.dependencies.trackRepository.sendFlutterCrash(crashEvent)
@@ -495,16 +500,6 @@ public enum NubrickSDK {
             trackCrashes: trackCrashes,
             onTooltip: onTooltip
         )
-    }
-
-    @MainActor
-    static func updateBridgeCallbacks(
-        onEvent: (@Sendable (_ event: ComponentEvent) -> Void)?,
-        onDispatch: ((_ event: NubrickEvent) -> Void)?,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
-    ) {
-        guard let runtime = requireRuntime() else { return }
-        runtime.updateBridgeCallbacks(onEvent: onEvent, onDispatch: onDispatch, onTooltip: onTooltip)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Add `clearCallbacks()` method to `NubrickBridge` to allow resetting all bridge callbacks (onEvent, onDispatch, onTooltip)
- Propagate clear through `NubrickCore` → `OverlayViewController` → `TriggerViewController`
- Inline `NubrickSDK.updateBridgeCallbacks` static method directly into `NubrickBridge.updateCallbacks`, removing the unnecessary indirection

## Test plan
- [ ] Verify `NubrickBridge.clearCallbacks()` nils out all three callbacks
- [ ] Verify `NubrickBridge.updateCallbacks()` still works as before
- [ ] Confirm no regressions in bridge initialization flow