### PR TITLE
Fix localMinute calculation, SwiftUI view lifecycle, and auto-scroll guards

### DIFF
--- a/.github/workflows/test-ios.yaml
+++ b/.github/workflows/test-ios.yaml
@@ -56,4 +56,8 @@ jobs:
         run: pod spec lint
       - name: Verify version consistency
         run: |
-          test $(cat ./Nubrick.podspec | grep -E 's\.version\W+=' | grep -o -e '[0-9]\.[0-9]\.[0-9]') = $(cat ./Sources/Nubrick/sdk.swift | grep -E 'nubrickSdkVersion\W+=' | grep -o -e '[0-9]\.[0-9]\.[0-9]')
+          PODSPEC_VERSION="$(ruby -e 'text = File.read("Nubrick.podspec"); abort "missing podspec version" unless text =~ /spec\.version\s*=\s*"([^"]+)"/; puts $1')"
+          MARKETING_VERSION="$(ruby -e 'text = File.read("Nubrick/Nubrick.xcodeproj/project.pbxproj"); versions = text.scan(/MARKETING_VERSION = ([^;]+);/).flatten.uniq; abort "expected one MARKETING_VERSION, got #{versions.inspect}" unless versions.length == 1; puts versions.first')"
+          PACKAGE_VERSION="$(ruby -e 'text = File.read("Package.swift"); abort "missing Package.swift release URL version" unless text =~ %r{/download/v([0-9]+\.[0-9]+\.[0-9]+)/Nubrick\.xcframework\.zip}; puts $1')"
+          test "$PODSPEC_VERSION" = "$MARKETING_VERSION"
+          test "$PODSPEC_VERSION" = "$PACKAGE_VERSION"

--- a/Sources/Nubrick/Component/embedding.swift
+++ b/Sources/Nubrick/Component/embedding.swift
@@ -198,34 +198,30 @@ class EmbeddingSwiftViewModel: ObservableObject {
         modalViewController: ModalComponentViewController?,
         onEvent: ((_ event: ComponentEvent) -> Void)?,
         onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
-    ) {
-        Task {
-            let result = await container.fetchEmbedding(experimentId: experimentId, componentId: componentId)
-            await MainActor.run { [weak self] in
-                switch result {
-                case .success(let view):
-                    switch view {
-                    case .EUIRootBlock(let root):
-                        self?.phase = .completed(AnyView(
-                            ComponentView(
-                                root: root,
-                                container: container,
-                                modalViewController: modalViewController,
-                                onEvent: onEvent,
-                                onSizeChange: onSizeChange
-                            )
-                        ))
-                    default:
-                        self?.phase = .notFound
-                    }
-                case .failure(let err):
-                    switch err {
-                    case .notFound:
-                        self?.phase = .notFound
-                    default:
-                        self?.phase = .failed(err)
-                    }
-                }
+    ) async {
+        let result = await container.fetchEmbedding(experimentId: experimentId, componentId: componentId)
+        switch result {
+        case .success(let view):
+            switch view {
+            case .EUIRootBlock(let root):
+                self.phase = .completed(AnyView(
+                    ComponentView(
+                        root: root,
+                        container: container,
+                        modalViewController: modalViewController,
+                        onEvent: onEvent,
+                        onSizeChange: onSizeChange
+                    )
+                ))
+            default:
+                self.phase = .notFound
+            }
+        case .failure(let err):
+            switch err {
+            case .notFound:
+                self.phase = .notFound
+            default:
+                self.phase = .failed(err)
             }
         }
     }
@@ -233,8 +229,22 @@ class EmbeddingSwiftViewModel: ObservableObject {
 }
 
 struct EmbeddingSwiftView: View {
+    private struct FetchKey: Equatable {
+        let experimentId: String
+        let componentId: String?
+    }
+
     @ViewBuilder private let _content: ((_ phase: SwiftUIEmbeddingPhase) -> AnyView)
-    @ObservedObject private var data: EmbeddingSwiftViewModel
+    @StateObject private var data = EmbeddingSwiftViewModel()
+    private let experimentId: String
+    private let componentId: String?
+    private let container: Container
+    private let modalViewController: ModalComponentViewController?
+    private let onEvent: ((_ event: ComponentEvent) -> Void)?
+    private let onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
+    private var fetchKey: FetchKey {
+        FetchKey(experimentId: experimentId, componentId: componentId)
+    }
     
     init(
         experimentId: String,
@@ -244,6 +254,12 @@ struct EmbeddingSwiftView: View {
         onEvent: ((_ event: ComponentEvent) -> Void)?,
         onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
+        self.experimentId = experimentId
+        self.componentId = componentId
+        self.container = container
+        self.modalViewController = modalViewController
+        self.onEvent = onEvent
+        self.onSizeChange = onSizeChange
         self._content = { phase in
             switch phase {
             case .completed(let component):
@@ -254,14 +270,6 @@ struct EmbeddingSwiftView: View {
                 return AnyView(EmptyView())
             }
         }
-        self.data = EmbeddingSwiftViewModel()
-        self.data.fetchEmbeddingAndUpdatePhase(
-            experimentId: experimentId,
-            container: container,
-            modalViewController: modalViewController,
-            onEvent: onEvent,
-            onSizeChange: onSizeChange
-        )
     }
 
     init<V: View>(
@@ -273,20 +281,31 @@ struct EmbeddingSwiftView: View {
         content: @escaping ((_ phase: SwiftUIEmbeddingPhase) -> V),
         onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
+        self.experimentId = experimentId
+        self.componentId = componentId
+        self.container = container
+        self.modalViewController = modalViewController
+        self.onEvent = onEvent
+        self.onSizeChange = onSizeChange
         self._content = { phase in
             AnyView(content(phase))
         }
-        self.data = EmbeddingSwiftViewModel()
-        self.data.fetchEmbeddingAndUpdatePhase(
-            experimentId: experimentId,
-            container: container,
-            modalViewController: modalViewController,
-            onEvent: onEvent,
-            onSizeChange: onSizeChange
-        )
     }
 
     var body: some View {
-        self._content(data.phase)
+        // ZStack provides a concrete mounted host even when phase content is EmptyView to make sure .task runs
+        ZStack {
+            self._content(data.phase)
+        }
+            .task(id: fetchKey) {
+                await data.fetchEmbeddingAndUpdatePhase(
+                    experimentId: experimentId,
+                    componentId: componentId,
+                    container: container,
+                    modalViewController: modalViewController,
+                    onEvent: onEvent,
+                    onSizeChange: onSizeChange
+                )
+            }
     }
 }

--- a/Sources/Nubrick/Component/renderer/collection.swift
+++ b/Sources/Nubrick/Component/renderer/collection.swift
@@ -239,6 +239,7 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
         return self.block?.data?.kind == CollectionKind.CAROUSEL
             && self.block?.data?.fullItemWidth == true
             && self.block?.data?.autoScroll == true
+            && self.childrenCount > 1
     }
 
     private func startAutoScrollTimerIfNeeded() {
@@ -355,6 +356,9 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
     }
     
     func automaticScroll() {
+        guard self.childrenCount > 0 else {
+            return
+        }
         if self.counter >= self.childrenCount - 1 {
             self.counter = 0
         } else {

--- a/Sources/Nubrick/Data/database/helper.swift
+++ b/Sources/Nubrick/Data/database/helper.swift
@@ -68,10 +68,19 @@ final class UserEventEntity: NSManagedObject {
     }
 }
 
-func createNativebrikCoreDataHelper() -> NSPersistentContainer? {
+@MainActor
+private let nativebrikManagedObjectModel: NSManagedObjectModel = {
     let model = NSManagedObjectModel()
-    model.entities = [UserEventEntity.entityDescription(), ExperimentHistoryEntity.entityDescription()]
-    let container = NSPersistentContainer(name: "com.nativebrik.sdk", managedObjectModel: model)
+    model.entities = [
+        UserEventEntity.entityDescription(),
+        ExperimentHistoryEntity.entityDescription(),
+    ]
+    return model
+}()
+
+@MainActor
+func createNativebrikCoreDataHelper() -> NSPersistentContainer? {
+    let container = NSPersistentContainer(name: "com.nativebrik.sdk", managedObjectModel: nativebrikManagedObjectModel)
     container.persistentStoreDescriptions.first?.shouldAddStoreAsynchronously = false
 
     var loadError: Error?

--- a/Sources/Nubrick/Data/user.swift
+++ b/Sources/Nubrick/Data/user.swift
@@ -255,7 +255,7 @@ class NubrickUser {
             ),
             UserProperty(
                 name: BuiltinUserProperty.localMinute.rawValue,
-                value: String(localDates.hour * 60 * localDates.minute),
+                value: String(localDates.hour * 60 + localDates.minute),
                 type: .INTEGER
             ),
             UserProperty(

--- a/Sources/Nubrick/remote-config.swift
+++ b/Sources/Nubrick/remote-config.swift
@@ -232,7 +232,10 @@ class RemoteConfigSwiftViewModel: ObservableObject {
 
 struct RemoteConfigAsView: View {
     @ViewBuilder private let content: ((_ phase: RemoteConfigPhase) -> AnyView)
-    @ObservedObject private var data: RemoteConfigSwiftViewModel
+    @StateObject private var data = RemoteConfigSwiftViewModel()
+    private let experimentId: String
+    private let container: Container
+    private let modalViewController: ModalComponentViewController
     
     init<V: View>(
         experimentId: String,
@@ -240,18 +243,25 @@ struct RemoteConfigAsView: View {
         modalViewController: ModalComponentViewController,
         content: @escaping (_: RemoteConfigPhase) -> V
     ) {
+        self.experimentId = experimentId
+        self.container = container
+        self.modalViewController = modalViewController
         self.content = { phase in
             AnyView(content(phase))
         }
-        self.data = RemoteConfigSwiftViewModel()
-        self.data.fetchAndUpdate(
-            experimentId: experimentId,
-            container: container,
-            modalViewController: modalViewController
-        )
     }
 
     var body: some View {
-        self.content(data.phase)
+        // ZStack provides a concrete mounted host even when phase content is EmptyView to make sure .task runs
+        ZStack {
+            self.content(data.phase)
+        }
+            .task(id: experimentId) {
+                data.fetchAndUpdate(
+                    experimentId: experimentId,
+                    container: container,
+                    modalViewController: modalViewController
+                )
+            }
     }
 }

--- a/Tests/NubrickTests/Data/user.swift
+++ b/Tests/NubrickTests/Data/user.swift
@@ -70,4 +70,24 @@ final class UserTests: XCTestCase {
         XCTAssertEqual(customUserId, userIdProp?.value)
         XCTAssertEqual("world", customProp?.value)
     }
+
+    func testLocalMinuteIsMinuteOfDay() {
+        let user = NubrickUser()
+
+        for _ in 0..<3 {
+            let before = getLocalDateComponent(getCurrentDate())
+            let props = user.toEventProperties(seed: 0)
+            let after = getLocalDateComponent(getCurrentDate())
+
+            guard before.hour == after.hour, before.minute == after.minute else {
+                continue
+            }
+
+            let localMinute = props.first { $0.name == BuiltinUserProperty.localMinute.rawValue }?.value
+            XCTAssertEqual(String(before.hour * 60 + before.minute), localMinute)
+            return
+        }
+
+        XCTFail("Could not read localMinute without crossing a minute boundary")
+    }
 }


### PR DESCRIPTION
## Summary

- **Fix `localMinute` bug**: `hour * 60 * minute` → `hour * 60 + minute` to correctly compute minute-of-day, with test
- **SwiftUI lifecycle fix**: Convert `EmbeddingSwiftView` and `RemoteConfigAsView` from `@ObservedObject` + init-time fetch to `@StateObject` + `.task(id:)` for proper SwiftUI lifecycle ownership. Make `fetchEmbeddingAndUpdatePhase` async so `.task` cancellation propagates to the fetch
- **Auto-scroll guards**: Skip auto-scroll for single-item carousels (`childrenCount > 1`) and guard `automaticScroll()` against empty collections
- **Core Data model singleton**: Extract `NSManagedObjectModel` to a file-level lazy `let` to avoid rebuilding entity descriptions on every call
- **CI version check**: Replace fragile grep-based version consistency check with Ruby parsing that handles multi-digit versions and validates podspec, Xcode `MARKETING_VERSION`, and `Package.swift` download URL

## Test plan
- [ ] Verify `testLocalMinuteIsMinuteOfDay` passes
- [ ] Test embedding and remote-config SwiftUI views render correctly
- [ ] Test carousel auto-scroll with 0 and 1 items does not crash
- [ ] CI version consistency check passes