### PR TITLE
Fix total calculation to sum values instead of counting entries

### DIFF
--- a/Sources/Nubrick/Data/database/database.swift
+++ b/Sources/Nubrick/Data/database/database.swift
@@ -104,7 +104,7 @@ final class DatabaseRepositoryImpl: DatabaseRepository {
             since: condition.since
         )
 
-        let total = counts.values.count
+        let total = counts.values.reduce(0, +)
         return compareInteger(a: total, b: [threshold], op: condition.comparison ?? .Equal)
     }
 


### PR DESCRIPTION
## Summary
- Fixed bug in `DatabaseRepositoryImpl` where `counts.values.count` was counting the number of dictionary entries instead of summing the actual values
- Replaced with `counts.values.reduce(0, +)` to correctly compute the total across all count entries
- This ensures threshold comparisons work correctly when there are multiple keys or values greater than 1

## Test plan
- [ ] Verify condition evaluation with multiple count entries returns the correct sum
- [ ] Verify threshold comparison still works for single-entry counts