### PR TITLE
Make appendExperimentHistory async and fix typos

### DIFF
--- a/Sources/Nubrick/Data/container.swift
+++ b/Sources/Nubrick/Data/container.swift
@@ -175,7 +175,7 @@ final class ContainerImpl: Container {
         await self.trackRepository.trackExperimentEvent(TrackExperimentEvent(
             experimentId: extracted.experimentId, variantId: variantId
         ))
-        self.databaseRepository.appendExperimentHistory(experimentId: extracted.experimentId)
+        await self.databaseRepository.appendExperimentHistory(experimentId: extracted.experimentId)
 
         guard let componentId = extractComponentId(variant: extracted.variant) else {
             return Result.failure(NubrickError.notFound)
@@ -214,7 +214,7 @@ final class ContainerImpl: Container {
         // Tooltip is a Flutter-only flow. Persist tooltip history only after
         // Flutter confirms the tooltip actually started rendering.
         if extracted.kind != .TOOLTIP {
-            self.databaseRepository.appendExperimentHistory(experimentId: extracted.experimentId)
+            await self.databaseRepository.appendExperimentHistory(experimentId: extracted.experimentId)
         }
 
         guard let componentId = extractComponentId(variant: extracted.variant) else {
@@ -253,7 +253,7 @@ final class ContainerImpl: Container {
         await self.trackRepository.trackExperimentEvent(TrackExperimentEvent(
             experimentId: extracted.experimentId, variantId: variantId
         ))
-        self.databaseRepository.appendExperimentHistory(experimentId: extracted.experimentId)
+        await self.databaseRepository.appendExperimentHistory(experimentId: extracted.experimentId)
 
         return Result.success((extracted.experimentId, extracted.variant))
     }

--- a/Sources/Nubrick/Data/database/database.swift
+++ b/Sources/Nubrick/Data/database/database.swift
@@ -10,7 +10,7 @@ import CoreData
 
 protocol DatabaseRepository : Sendable {
     func appendUserEvent(name: String) async
-    func appendExperimentHistory(experimentId: String)
+    func appendExperimentHistory(experimentId: String) async
     func isNotInFrequency(experimentId: String, frequency: ExperimentFrequency?) async -> Boolean
     func isMatchedToUserEventFrequencyCondition(condition: UserEventFrequencyCondition?) async -> Boolean
 }
@@ -32,24 +32,22 @@ final class DatabaseRepositoryImpl: DatabaseRepository {
             do {
                 try context.save()
             } catch {
-                print("Cound'nt save UserEventEntity \(error)")
+                print("Couldn't save UserEventEntity \(error)")
             }
         }
     }
 
-    func appendExperimentHistory(experimentId: String) {
+    func appendExperimentHistory(experimentId: String) async {
         let persistentContainer = self.persistentContainer
-        Task {
-            await MainActor.run {
-                let context = persistentContainer.viewContext
-                let history = ExperimentHistoryEntity(context: context)
-                history.experimentId = experimentId
-                history.timestamp = getCurrentDate()
-                do {
-                    try context.save()
-                } catch {
-                    print("Cound'nt save ExperimentHistoryEntity \(error)")
-                }
+        await MainActor.run {
+            let context = persistentContainer.viewContext
+            let history = ExperimentHistoryEntity(context: context)
+            history.experimentId = experimentId
+            history.timestamp = getCurrentDate()
+            do {
+                try context.save()
+            } catch {
+                print("Couldn't save ExperimentHistoryEntity \(error)")
             }
         }
     }

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -246,9 +246,9 @@ final class NubrickCore {
         self.dependencies.user.getProperties()
     }
 
-    func appendTooltipExperimentHistory(experimentId: String) {
+    func appendTooltipExperimentHistory(experimentId: String) async {
         guard !experimentId.isEmpty else { return }
-        self.dependencies.databaseRepository.appendExperimentHistory(experimentId: experimentId)
+        await self.dependencies.databaseRepository.appendExperimentHistory(experimentId: experimentId)
     }
 
     func processMetricKitCrash(
@@ -635,11 +635,11 @@ public enum NubrickSDK {
 
     @_spi(FlutterBridge)
     @MainActor
-    public static func appendTooltipExperimentHistory(experimentId: String) {
+    public static func appendTooltipExperimentHistory(experimentId: String) async {
         guard let runtime = requireRuntime() else {
             return
         }
-        runtime.appendTooltipExperimentHistory(experimentId: experimentId)
+        await runtime.appendTooltipExperimentHistory(experimentId: experimentId)
     }
 
     @available(*, deprecated, message: "NSException-based crash reporting has been replaced by MetricKit. This method no longer reports crashes. Crash reporting now happens automatically via MetricKit on iOS 14+.")


### PR DESCRIPTION
## Summary
- Remove fire-and-forget `Task` wrapper from `appendExperimentHistory`, making it a proper `async` method that callers `await`. This ensures CoreData persistence completes before callers proceed, preventing potential race conditions.
- Propagate `async`/`await` to all call sites in `ContainerImpl`, `NubrickCore`, and `NubrickSDK`.
- Fix "Cound'nt" typos in error messages.