### PR TITLE
Harden property comparison and fix timestamp parsing

### DIFF
--- a/Sources/Nubrick/Data/extraction/extraction.swift
+++ b/Sources/Nubrick/Data/extraction/extraction.swift
@@ -154,19 +154,29 @@ func isInDistribution(distribution: [ExperimentCondition], properties: [UserProp
 }
 
 func comparePropWithConditionValue(prop: UserProperty, asType: UserPropertyType?, value: String, op: ConditionOperator) -> Bool {
-    let values = value.split(separator: ",")
+    let values = value.split(separator: ",", omittingEmptySubsequences: false)
     let propType = asType ?? prop.type
     switch propType {
     case .INTEGER:
-        let propValue = Int(prop.value) ?? 0
-        let conditionValues = values.map { value in
-            return Int(value) ?? 0
+        guard let propValue = Int(prop.value.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return false
+        }
+        let conditionValues = values.compactMap { value in
+            return Int(String(value).trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        if conditionValues.count != values.count {
+            return false
         }
         return compareInteger(a: propValue, b: conditionValues, op: op)
     case .DOUBLE:
-        let propValue = Double(prop.value) ?? 0
-        let conditionValues = values.map { value in
-            return Double(value) ?? 0
+        guard let propValue = Double(prop.value.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return false
+        }
+        let conditionValues = values.compactMap { value in
+            return Double(String(value).trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        if conditionValues.count != values.count {
+            return false
         }
         return compareDouble(a: propValue, b: conditionValues, op: op)
     case .STRING:
@@ -176,25 +186,76 @@ func comparePropWithConditionValue(prop: UserProperty, asType: UserPropertyType?
         return compareString(a: prop.value, b: strings, op: op)
     case .SEMVER:
         let strings: [String] = values.map { value in
-            return String(value)
+            return String(value).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if strings.contains(where: { $0.isEmpty }) {
+            return false
         }
         return compareSemver(a: prop.value, b: strings, op: op)
     case .TIMESTAMPZ:
-        let dateFormatter = DateFormatter()
-        let propValue = dateFormatter.date(from: prop.value)?.timeIntervalSince1970 ?? 0
-        let conditionValues = values.map { value in
-            return dateFormatter.date(from: String(value))?.timeIntervalSince1970 ?? 0
+        guard let propValue = parseTimestampZAsUnixSeconds(prop.value) else {
+            return false
+        }
+        let conditionValues = values.compactMap { value in
+            return parseTimestampZAsUnixSeconds(String(value))
+        }
+        if conditionValues.count != values.count {
+            return false
         }
         return compareDouble(a: propValue, b: conditionValues, op: op)
     case .BOOLEAN:
         let propValue = parseStringToBoolean(prop.value)
-        let conditionValues = values.map { value in
-            return parseStringToBoolean(String(value))
+        let strings: [String] = values.map { value in
+            return String(value).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if strings.contains(where: { $0.isEmpty }) {
+            return false
+        }
+        let conditionValues = strings.map { value in
+            return parseStringToBoolean(value)
         }
         return compareBoolean(a: propValue, b: conditionValues, op: op)
     default:
         return false
     }
+}
+
+private let iso8601ParseStrategies: [Date.ISO8601FormatStyle] = [
+    .iso8601.year().month().day().time(includingFractionalSeconds: true).timeZone(separator: .colon),
+    .iso8601.year().month().day().time(includingFractionalSeconds: false).timeZone(separator: .colon),
+    .iso8601.year().month().day().time(includingFractionalSeconds: true).timeZone(separator: .omitted),
+    .iso8601.year().month().day().time(includingFractionalSeconds: false).timeZone(separator: .omitted),
+    .iso8601.year().month().day().time(includingFractionalSeconds: false),
+    .iso8601.year().month().day(),
+]
+
+private let fallbackParseStrategy = Date.ParseStrategy(
+    format: "\(year: .defaultDigits)-\(month: .twoDigits)-\(day: .twoDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits):\(second: .twoDigits) \(timeZone: .iso8601(.short))",
+    locale: Locale(identifier: "en_US_POSIX"),
+    timeZone: .current
+)
+
+func parseTimestampZAsUnixSeconds(_ value: String) -> Double? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+        return nil
+    }
+
+    if let timestamp = Int64(trimmed) {
+        return Double(timestamp)
+    }
+
+    for strategy in iso8601ParseStrategies {
+        if let date = try? Date(trimmed, strategy: strategy) {
+            return Double(Int64(date.timeIntervalSince1970))
+        }
+    }
+
+    if let date = try? Date(trimmed, strategy: fallbackParseStrategy) {
+        return Double(Int64(date.timeIntervalSince1970))
+    }
+
+    return nil
 }
 
 func compareInteger(a: Int, b: [Int], op: ConditionOperator) -> Bool {

--- a/Sources/Nubrick/Data/user.swift
+++ b/Sources/Nubrick/Data/user.swift
@@ -55,6 +55,13 @@ private let USER_CUSTOM_PROPERTY_KEY_PREFIX = "NATIVEBRIK_CUSTOM_"
 private let USER_SEED_KEY: String = "NATIVEBRIK_USER_SEED"
 private let USER_SEED_MAX: Int = 100000000
 
+private func formatUserPropertyValue(_ value: Any) -> String {
+    if let date = value as? Date {
+        return date.ISO8601Format()
+    }
+    return String(describing: value)
+}
+
 @MainActor
 class NubrickUser {
     private var properties: [String: String]
@@ -142,7 +149,7 @@ class NubrickUser {
             return
         }
 
-        let strValue = String(describing: value)
+        let strValue = formatUserPropertyValue(value)
         self.customProperties[key] = strValue
         self.userDB.set(strValue, forKey: USER_CUSTOM_PROPERTY_KEY_PREFIX + key)
     }

--- a/Tests/NubrickTests/Data/extraction/extractionTests.swift
+++ b/Tests/NubrickTests/Data/extraction/extractionTests.swift
@@ -329,6 +329,165 @@ final class CompareTests: XCTestCase {
         XCTAssertTrue(comparePropWithConditionValue(
             prop: UserProperty(name: "xxx", value: "12.3", type: .STRING), asType: .SEMVER, value: "12", op: .Equal))
     }
+
+    func testCompareTimestampZWithISO8601PropAndUnixCondition() throws {
+        let timestamp = 1_717_200_000
+        let prop = UserProperty(
+            name: BuiltinUserProperty.currentTime.rawValue,
+            value: Date(timeIntervalSince1970: Double(timestamp)).ISO8601Format(),
+            type: .TIMESTAMPZ
+        )
+
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: String(timestamp),
+            op: .Equal
+        ))
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: String(timestamp - 1),
+            op: .GreaterThan
+        ))
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: "\(timestamp - 1),\(timestamp + 1)",
+            op: .Between
+        ))
+    }
+
+    func testCompareTimestampZDoesNotTreatUnixMillisecondsAsSeconds() throws {
+        let timestamp = 1_717_200_000
+        let prop = UserProperty(
+            name: BuiltinUserProperty.currentTime.rawValue,
+            value: Date(timeIntervalSince1970: Double(timestamp)).ISO8601Format(),
+            type: .TIMESTAMPZ
+        )
+
+        XCTAssertFalse(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: String(timestamp * 1000),
+            op: .Equal
+        ))
+    }
+
+    func testCompareTimestampZWithRFC3339Condition() throws {
+        let prop = UserProperty(
+            name: BuiltinUserProperty.currentTime.rawValue,
+            value: "2024-06-01T00:00:00Z",
+            type: .TIMESTAMPZ
+        )
+
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: "2024-06-01T00:00:00.000Z",
+            op: .Equal
+        ))
+    }
+
+    func testCompareTimestampZWithColonTimezoneOffset() throws {
+        let prop = UserProperty(
+            name: BuiltinUserProperty.currentTime.rawValue,
+            value: "2024-06-01T00:00:00+00:00",
+            type: .TIMESTAMPZ
+        )
+
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: "2024-06-01T00:00:00Z",
+            op: .Equal
+        ))
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: "2024-06-01T00:00:00.000+00:00",
+            op: .Equal
+        ))
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: "1717200000",
+            op: .Equal
+        ))
+    }
+
+    func testCompareTimestampZWithNonZeroColonTimezoneOffset() throws {
+        let prop = UserProperty(
+            name: BuiltinUserProperty.currentTime.rawValue,
+            value: "2024-06-01T09:00:00+09:00",
+            type: .TIMESTAMPZ
+        )
+
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: "2024-06-01T00:00:00Z",
+            op: .Equal
+        ))
+    }
+
+    func testCompareTimestampZWithLocalDateTimeString() throws {
+        let prop = UserProperty(
+            name: BuiltinUserProperty.currentTime.rawValue,
+            value: "2024-06-01T09:30:00",
+            type: .TIMESTAMPZ
+        )
+
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: "2024-06-01T09:30:00",
+            op: .Equal
+        ))
+    }
+
+    func testCompareTimestampZWithLocalDateString() throws {
+        let prop = UserProperty(
+            name: BuiltinUserProperty.currentTime.rawValue,
+            value: "2024-06-01",
+            type: .TIMESTAMPZ
+        )
+
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: "2024-06-01",
+            op: .Equal
+        ))
+    }
+
+    func testCompareTimestampZWithDateDescriptionString() throws {
+        let prop = UserProperty(
+            name: BuiltinUserProperty.currentTime.rawValue,
+            value: "2024-06-01 00:00:00 +0000",
+            type: .TIMESTAMPZ
+        )
+
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop,
+            asType: nil,
+            value: "2024-06-01T00:00:00Z",
+            op: .Equal
+        ))
+    }
+
+    func testCompareTimestampZReturnsFalseWhenTimestampCannotBeParsed() throws {
+        XCTAssertFalse(comparePropWithConditionValue(
+            prop: UserProperty(
+                name: BuiltinUserProperty.currentTime.rawValue,
+                value: "invalid",
+                type: .TIMESTAMPZ
+            ),
+            asType: nil,
+            value: "invalid",
+            op: .Equal
+        ))
+    }
     
     
     func testCompareSemverAsComparisonResultWhenOnlyMajorVersions() throws {
@@ -395,6 +554,14 @@ final class CompareTests: XCTestCase {
         XCTAssertTrue(compareSemver(a: "1.0", b: ["0.0.9", "1.0.1"], op: .Between))
         XCTAssertFalse(compareSemver(a: "1.0", b: ["1.0.1", "2"], op: .Between))
         XCTAssertFalse(compareSemver(a: "1.0", b: [], op: .Between))
+    }
+
+    func testCompareSemverRejectsEmptyConditionValues() throws {
+        let prop = UserProperty(name: "version", value: "1.0", type: .SEMVER)
+
+        XCTAssertFalse(comparePropWithConditionValue(prop: prop, asType: nil, value: "1,", op: .In))
+        XCTAssertFalse(comparePropWithConditionValue(prop: prop, asType: nil, value: "1,,2", op: .In))
+        XCTAssertFalse(comparePropWithConditionValue(prop: prop, asType: nil, value: "", op: .Equal))
     }
     
     func testCompareString() throws {
@@ -468,6 +635,17 @@ final class CompareTests: XCTestCase {
         XCTAssertFalse(compareDouble(a: 5, b: [10, 20], op: .Between))
         XCTAssertFalse(compareDouble(a: 5, b: [], op: .Between))
     }
+
+    func testCompareDoubleDoesNotTreatInvalidOrEmptyValuesAsZero() throws {
+        let invalidProp = UserProperty(name: "invalid", value: "invalid", type: .DOUBLE)
+        let zeroProp = UserProperty(name: "zero", value: "0", type: .DOUBLE)
+        let oneProp = UserProperty(name: "one", value: "1", type: .DOUBLE)
+
+        XCTAssertFalse(comparePropWithConditionValue(prop: invalidProp, asType: nil, value: "invalid", op: .Equal))
+        XCTAssertFalse(comparePropWithConditionValue(prop: zeroProp, asType: nil, value: "invalid", op: .NotIn))
+        XCTAssertFalse(comparePropWithConditionValue(prop: oneProp, asType: nil, value: "1,", op: .In))
+        XCTAssertFalse(comparePropWithConditionValue(prop: oneProp, asType: nil, value: "1,,2", op: .In))
+    }
     
     func testCompareInteger() throws {
         // equal
@@ -511,6 +689,26 @@ final class CompareTests: XCTestCase {
         XCTAssertFalse(compareInteger(a: 5, b: [10, 20], op: .Between))
         XCTAssertFalse(compareInteger(a: 5, b: [], op: .Between))
     }
+
+    func testCompareIntegerOutsideInt32Range() throws {
+        let prop = UserProperty(name: "long", value: "3000000000", type: .INTEGER)
+
+        XCTAssertTrue(comparePropWithConditionValue(prop: prop, asType: nil, value: "3000000000", op: .Equal))
+        XCTAssertFalse(comparePropWithConditionValue(prop: prop, asType: nil, value: "3000000001", op: .Equal))
+        XCTAssertTrue(comparePropWithConditionValue(prop: prop, asType: nil, value: "2999999999", op: .GreaterThan))
+        XCTAssertTrue(comparePropWithConditionValue(prop: prop, asType: nil, value: "3000000000,3000000001", op: .Between))
+    }
+
+    func testCompareIntegerDoesNotTreatInvalidValuesAsZero() throws {
+        let invalidProp = UserProperty(name: "invalid", value: "invalid", type: .INTEGER)
+        let zeroProp = UserProperty(name: "zero", value: "0", type: .INTEGER)
+        let oneProp = UserProperty(name: "one", value: "1", type: .INTEGER)
+
+        XCTAssertFalse(comparePropWithConditionValue(prop: invalidProp, asType: nil, value: "invalid", op: .Equal))
+        XCTAssertFalse(comparePropWithConditionValue(prop: zeroProp, asType: nil, value: "invalid", op: .NotIn))
+        XCTAssertFalse(comparePropWithConditionValue(prop: oneProp, asType: nil, value: "1,", op: .In))
+        XCTAssertFalse(comparePropWithConditionValue(prop: oneProp, asType: nil, value: "1,,2", op: .In))
+    }
     
     func testCompareBoolean() throws {
         // equal
@@ -520,6 +718,15 @@ final class CompareTests: XCTestCase {
         // not equal
         XCTAssertTrue(compareBoolean(a: false, b: [true], op: .NotEqual))
         XCTAssertFalse(compareBoolean(a: false, b: [false], op: .NotEqual))
+    }
+
+    func testCompareBooleanRejectsEmptyConditionValues() throws {
+        let trueProp = UserProperty(name: "bool", value: "true", type: .BOOLEAN)
+        let falseProp = UserProperty(name: "bool", value: "false", type: .BOOLEAN)
+
+        XCTAssertFalse(comparePropWithConditionValue(prop: trueProp, asType: nil, value: "true,", op: .In))
+        XCTAssertFalse(comparePropWithConditionValue(prop: falseProp, asType: nil, value: "true,,false", op: .In))
+        XCTAssertFalse(comparePropWithConditionValue(prop: falseProp, asType: nil, value: "", op: .Equal))
     }
     
     func testParseStrToBoolean() {

--- a/Tests/NubrickTests/Data/user.swift
+++ b/Tests/NubrickTests/Data/user.swift
@@ -71,6 +71,16 @@ final class UserTests: XCTestCase {
         XCTAssertEqual("world", customProp?.value)
     }
 
+    func testSetPropertyStoresDateAsISOInstant() {
+        let user = NubrickUser()
+        let key = "dateForIsoSerializationTest"
+
+        user.setProperty(key, value: Date(timeIntervalSince1970: 1_317_826_080))
+
+        XCTAssertEqual("2011-10-05T14:48:00Z", user.getProperty(key))
+        XCTAssertEqual(.STRING, user.toEventProperties(seed: 0).first { $0.name == key }?.type)
+    }
+
     func testLocalMinuteIsMinuteOfDay() {
         let user = NubrickUser()
 


### PR DESCRIPTION
## Summary
- Fix `comparePropWithConditionValue` to return `false` on unparseable values instead of silently defaulting to `0` for INTEGER, DOUBLE, and TIMESTAMPZ types
- Replace broken `DateFormatter()` (no format set) with `parseTimestampZAsUnixSeconds` supporting unix seconds, ISO 8601 with colon/omitted timezone separators, fractional seconds, local datetime, date-only, and `Date.description` fallback
- Reject empty condition values from trailing/double commas for SEMVER and BOOLEAN types
- Add whitespace trimming across all type branches
- Format `Date` values as ISO 8601 in `setProperty` instead of `String(describing:)`

## Test plan
- [x] Timestamp parsing: ISO 8601 ↔ unix cross-format equality, RFC 3339 fractional seconds, colon timezone offsets (`+00:00`), non-zero offsets (`+09:00`), date-only, `Date.description` format, invalid rejection
- [x] INTEGER: values outside Int32 range, invalid/empty value rejection
- [x] DOUBLE: invalid/empty value rejection
- [x] SEMVER: empty condition value rejection
- [x] BOOLEAN: empty condition value rejection
- [x] User property: Date stored as ISO 8601 instant string