### PR TITLE
Fix HTTP status handling, resilient UIBlock decoding, and remove unused config

### DIFF
--- a/Sources/Nubrick/Data/network.swift
+++ b/Sources/Nubrick/Data/network.swift
@@ -29,10 +29,13 @@ func getData(url: URL, syncDateTime: Bool = false) async -> Result<Data, Nubrick
         if syncDateTime {
             syncDateFromHTTPURLResponse(t0: t0, res: res)
         }
+        if 200 <= res.statusCode && res.statusCode <= 299 {
+            return Result.success(data)
+        }
         if res.statusCode == 404 {
             return Result.failure(NubrickError.notFound)
         }
-        return Result.success(data)
+        return Result.failure(NubrickError.unexpected)
     } catch {
         return Result.failure(NubrickError.other(error))
     }

--- a/Sources/Nubrick/Schema/generated.swift
+++ b/Sources/Nubrick/Schema/generated.swift
@@ -391,7 +391,7 @@ struct TriggerSetting: Decodable, Encodable {
   var onTrigger: UIBlockAction?
   var trigger: TriggerEventDef?
 }
-indirect enum UIBlock: Decodable, Encodable, Sendable {
+indirect enum UIBlock: Decodable, Encodable {
   case EUIRootBlock(UIRootBlock)
   case EUIPageBlock(UIPageBlock)
   case EUIFlexContainerBlock(UIFlexContainerBlock)
@@ -421,6 +421,10 @@ indirect enum UIBlock: Decodable, Encodable, Sendable {
     case __UIMultiSelectInputBlock = "UIMultiSelectInputBlock"
     case __UISwitchInputBlock = "UISwitchInputBlock"
     case unknown
+
+    init(from decoder: Decoder) throws {
+      self = try Typename(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+    }
   }
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -80,13 +80,11 @@ private func dispatchMainActor(_ event: NubrickEvent) {
 
 final class Config : Sendable{
     let projectId: String
-    let url: String
     let trackUrl: String
     let cdnUrl: String
 
     init(projectId: String) {
         self.projectId = projectId
-        self.url = "https://nativebrik.com/client"
         self.trackUrl = NubrickConstants.trackUrl
         self.cdnUrl = NubrickConstants.cdnUrl
     }

--- a/Tests/NubrickTests/Schema/decode.swift
+++ b/Tests/NubrickTests/Schema/decode.swift
@@ -44,4 +44,18 @@ final class DecodeJsonTests: XCTestCase {
         let result = try decoder.decode(UIBlockAction.self, from: Data(json.utf8))
         XCTAssertEqual("legacy_click", result.name)
     }
+
+    func testShouldDecodeUnknownUIBlockTypename() throws {
+        let decoder = JSONDecoder()
+        let json = """
+{"__typename":"UIButtonBlock","id":"unknown-block"}
+"""
+        let result = try decoder.decode(UIBlock.self, from: Data(json.utf8))
+        switch result {
+        case .unknown:
+            break
+        default:
+            XCTFail("Expected unknown UIBlock but got \(result)")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `getData` to return `.success` only for 2xx responses instead of all non-404 codes — previously 4xx/5xx errors were silently treated as valid data
- Add custom `Typename.init(from:)` on `UIBlock` to decode unrecognized `__typename` values as `.unknown` instead of throwing, matching the pattern used by `TriggerEventNameDefs`
- Remove `Sendable` conformance from `UIBlock` for consistency with other schema types
- Remove unused `url` property from `Config`
- Add test coverage for unknown UIBlock typename decoding

## Test plan
- [x] New test `testShouldDecodeUnknownUIBlockTypename` verifies unknown block types decode to `.unknown`
- [ ] Verify existing tests pass
- [ ] Confirm network requests with non-2xx responses now correctly return errors