### PR TITLE
Add reactive rendering updates

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - name: Build Nubrick E2E
-        run: xcodebuild -workspace ./Nubrick.xcworkspace -scheme E2E -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' -derivedDataPath ./.dist
+        run: xcodebuild -workspace ./Nubrick.xcworkspace -scheme E2E -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -derivedDataPath ./.dist
       - name: Zip app
         run: |
           cd .dist/Build/Products/Release-iphonesimulator/ && zip -r E2E.app.zip ./E2E.app

--- a/.github/workflows/test-ios.yaml
+++ b/.github/workflows/test-ios.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         scheme: [NubrickTests]
-        destination: ["platform=iOS Simulator,name=iPhone 17,OS=26.1"]
+        destination: ["platform=iOS Simulator,name=iPhone 17,OS=latest"]
     steps:
       - name: Install xcbeautify
         run: brew install xcbeautify

--- a/Nubrick/Nubrick.xcodeproj/project.pbxproj
+++ b/Nubrick/Nubrick.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		25C9F6AD2EB0597E00BD8267 /* experiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C9F65E2EB0597E00BD8267 /* experiment.swift */; };
 		25C9F6AE2EB0597E00BD8267 /* forms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C9F6472EB0597E00BD8267 /* forms.swift */; };
 		25C9F6B42EB0597E00BD8267 /* constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C9F6B52EB0597E00BD8267 /* constants.swift */; };
+		25C9F6B62EB0597E00BD8267 /* background-image-observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C9F6B72EB0597E00BD8267 /* background-image-observer.swift */; };
 		A1F000001111222233334451 /* dependency-container.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F000001111222233334441 /* dependency-container.swift */; };
 		25C9F6AF2EB0597E00BD8267 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 25C9F6742EB0597E00BD8267 /* PrivacyInfo.xcprivacy */; };
 		25C9F6B02EB0597E00BD8267 /* UIView+Yoga.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C9F67A2EB0597E00BD8267 /* UIView+Yoga.h */; };
@@ -108,6 +109,7 @@
 		25C9F6762EB0597E00BD8267 /* scalars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = scalars.swift; sourceTree = "<group>"; };
 		25C9F6772EB0597E00BD8267 /* sdk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sdk.swift; sourceTree = "<group>"; };
 		25C9F6B52EB0597E00BD8267 /* constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = constants.swift; sourceTree = "<group>"; };
+		25C9F6B72EB0597E00BD8267 /* background-image-observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "background-image-observer.swift"; sourceTree = "<group>"; };
 		25C9F6792EB0597E00BD8267 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		25C9F67A2EB0597E00BD8267 /* UIView+Yoga.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Yoga.h"; sourceTree = "<group>"; };
 		25C9F67B2EB0597E00BD8267 /* YGLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YGLayout.h; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 		25C9F64E2EB0597E00BD8267 /* renderer */ = {
 			isa = PBXGroup;
 			children = (
+				25C9F6B72EB0597E00BD8267 /* background-image-observer.swift */,
 				25C9F6432EB0597E00BD8267 /* block.swift */,
 				25C9F6442EB0597E00BD8267 /* carousel.swift */,
 				25C9F6452EB0597E00BD8267 /* collection.swift */,
@@ -435,6 +438,7 @@
 				25C9F6A32EB0597E00BD8267 /* UIView+Yoga.mm in Sources */,
 				25C9F6A42EB0597E00BD8267 /* sdk.swift in Sources */,
 				25C9F6A52EB0597E00BD8267 /* flex.swift in Sources */,
+				25C9F6B62EB0597E00BD8267 /* background-image-observer.swift in Sources */,
 				25C9F6A62EB0597E00BD8267 /* extraction.swift in Sources */,
 				25C9F6A72EB0597E00BD8267 /* block.swift in Sources */,
 				25C9F6A82EB0597E00BD8267 /* gif.swift in Sources */,

--- a/Sources/Nubrick/Component/action-listener.swift
+++ b/Sources/Nubrick/Component/action-listener.swift
@@ -171,7 +171,11 @@ func makeDisabledStateListener(target: UIView, context: UIBlockContext, required
 func compileAction(action: UIBlockAction, context: UIBlockContext?) -> UIBlockAction {
     guard let context = context else { return action }
 
-    let variable = context.getVariable()
+    return compileAction(action: action, variable: context.getVariable())
+}
+
+@MainActor
+func compileAction(action: UIBlockAction, variable: Variable?) -> UIBlockAction {
     let deepLink = action.deepLink
     let eventName = action.eventName ?? action.name
     let legacyName = action.name ?? action.eventName

--- a/Sources/Nubrick/Component/context.swift
+++ b/Sources/Nubrick/Component/context.swift
@@ -5,72 +5,90 @@
 //  Created by Ryosuke Suzuki on 2023/03/28.
 //
 
+import Combine
 import Foundation
+import UIKit
 
 typealias UIBlockActionHandler = @MainActor (_ action: UIBlockAction, _ onHttpSettled: (() -> Void)?) -> Void
 
 struct UIBlockContextInit {
     var container: Container? = nil
-    var variable: Variable? = nil
-    var childData: Any? = nil
+    var variableStore: VariableStore? = nil
     var properties: [Property]? = nil
     var actionHandler: UIBlockActionHandler? = nil
     var parentClickListener: ClickListener? = nil
     var parentDirection: FlexDirection? = nil
+    var layoutInvalidationRoot: UIView? = nil
     var loading: Bool? = false
 }
 
 struct UIBlockContextChildInit {
-    var childData: Any? = nil
+    var variable: Variable? = nil
+    var variableMapper: ((_ variable: Variable?) -> Variable?)? = nil
     var properties: [Property]? = nil
     var actionHandler: UIBlockActionHandler? = nil
     var parentClickListener: ClickListener? = nil
     var parentDirection: FlexDirection? = nil
+    var layoutInvalidationRoot: UIView? = nil
     var loading: Bool? = false
 }
 
 @MainActor
 class UIBlockContext {
-    private let variable: Variable?
     // page properties
     private let properties: [Property]?
     private let container: Container?
     private let actionHandler: UIBlockActionHandler?
+    private let variableStore: VariableStore
     private var parentClickListener: ClickListener?
     private var parentDirection: FlexDirection?
+    private weak var layoutInvalidationRoot: UIView?
     private var loading: Bool = false
 
     init(_ args: UIBlockContextInit) {
-        self.variable = args.variable
+        self.variableStore = args.variableStore ?? VariableStore()
         self.properties = args.properties
         self.actionHandler = args.actionHandler
         self.parentClickListener = args.parentClickListener
         self.parentDirection = args.parentDirection
+        self.layoutInvalidationRoot = args.layoutInvalidationRoot
         self.loading = args.loading ?? false
         self.container = args.container
     }
 
     func instanciateFrom(_ args: UIBlockContextChildInit) -> UIBlockContext {
-        var v = self.variable
-        if let childData = args.childData {
-            v = _mergeVariable(
-                base: v, self.container?.createVariableForTemplate(data: childData, properties: nil)
-            )
+        let variableStore: VariableStore
+        if let variableMapper = args.variableMapper {
+            variableStore = self.variableStore.derived(variableMapper)
+        } else if let variable = args.variable {
+            variableStore = VariableStore(variable)
+        } else {
+            variableStore = self.variableStore
         }
+
         return UIBlockContext(
             UIBlockContextInit(
                 container: self.container,
-                variable: v,
+                variableStore: variableStore,
                 properties: args.properties ?? self.properties,
                 actionHandler: args.actionHandler ?? self.actionHandler,
                 parentClickListener: args.parentClickListener ?? self.parentClickListener,
                 parentDirection: args.parentDirection ?? self.parentDirection,
+                layoutInvalidationRoot: args.layoutInvalidationRoot ?? self.layoutInvalidationRoot,
                 loading: args.loading ?? self.loading
             ))
     }
 
     func getVariable() -> Variable? {
-        return self.variable
+        return self.variableStore.variable
+    }
+
+    func variablePublisher() -> AnyPublisher<Variable?, Never> {
+        return self.variableStore.publisher()
+    }
+
+    func getLayoutInvalidationRoot() -> UIView? {
+        return self.layoutInvalidationRoot
     }
 
     func isLoading() -> Bool {
@@ -124,43 +142,4 @@ class UIBlockContext {
         return self.parentClickListener
     }
 
-    func getByReferenceKey(key: String?) -> Any? {
-        return variableByPath(path: key ?? "", variable: self.variable?.value)
-    }
-
-    func getArrayByReferenceKey(key: String?) -> [Any]? {
-        if let value = self.getByReferenceKey(key: key) as? [Any] {
-            return value
-        }
-        return nil
-    }
-
-    func getStringByReferenceKey(key: String?) -> String? {
-        if let value = self.getByReferenceKey(key: key) as? String {
-            return value
-        }
-        return nil
-    }
-
-    func getFloatByReferenceKey(key: String?) -> Float? {
-        let value = self.getByReferenceKey(key: key)
-        if let value = value as? Double {
-            return Float(value)
-        }
-        if let value = value as? Int {
-            return Float(value)
-        }
-        return nil
-    }
-
-    func getIntByReferenceKey(key: String?) -> Int? {
-        let value = self.getByReferenceKey(key: key)
-        if let value = value as? Int {
-            return value
-        }
-        if let value = value as? Double {
-            return Int(value)
-        }
-        return nil
-    }
 }

--- a/Sources/Nubrick/Component/embedding.swift
+++ b/Sources/Nubrick/Component/embedding.swift
@@ -48,7 +48,7 @@ class EmbeddingUIView: UIView {
     private let fallback: ((_ phase: UIKitEmbeddingPhase) -> UIView)
     private var fallbackView: UIView = UIView()
     
-    @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(experimentId:componentId:container:modalViewController:onEvent:fallback:onSizeChange:).")
+    @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(experimentId:componentId:container:arguments:modalViewController:onEvent:fallback:onSizeChange:).")
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -57,6 +57,7 @@ class EmbeddingUIView: UIView {
         experimentId: String,
         componentId: String? = nil,
         container: Container,
+        arguments: NubrickArguments? = nil,
         modalViewController: ModalComponentViewController?,
         onEvent: ((_ event: ComponentEvent) -> Void)?,
         fallback: ((_ phase: UIKitEmbeddingPhase) -> UIView)?,
@@ -95,6 +96,7 @@ class EmbeddingUIView: UIView {
                         let rootView = RootView(
                             root: root,
                             container: container,
+                            arguments: arguments,
                             modalViewController: modalViewController,
                             onEvent: { event in
                                 onEvent?(convertEvent(event))
@@ -141,6 +143,7 @@ struct ComponentView: View {
 
     let root: UIRootBlock?
     let container: Container
+    let arguments: NubrickArguments?
     let modalViewController: ModalComponentViewController?
     let onEvent: ((_ event: ComponentEvent) -> Void)?
     let onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
@@ -167,6 +170,7 @@ struct ComponentView: View {
         RootViewRepresentable(
             root: root,
             container: container,
+            arguments: arguments,
             modalViewController: modalViewController,
             onEvent: { event in
                 onEvent?(convertEvent(event))
@@ -187,41 +191,37 @@ public enum SwiftUIEmbeddingPhase {
     case failed(Error)
 }
 
+fileprivate enum FetchState {
+    case loading
+    case completed(UIRootBlock)
+    case notFound
+    case failed(Error)
+}
+
 @MainActor
 class EmbeddingSwiftViewModel: ObservableObject {
-    @Published var phase: SwiftUIEmbeddingPhase = .loading
+    @Published fileprivate var state: FetchState = .loading
 
     func fetchEmbeddingAndUpdatePhase(
         experimentId: String,
         componentId: String? = nil,
-        container: Container,
-        modalViewController: ModalComponentViewController?,
-        onEvent: ((_ event: ComponentEvent) -> Void)?,
-        onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
+        container: Container
     ) async {
         let result = await container.fetchEmbedding(experimentId: experimentId, componentId: componentId)
         switch result {
         case .success(let view):
             switch view {
             case .EUIRootBlock(let root):
-                self.phase = .completed(AnyView(
-                    ComponentView(
-                        root: root,
-                        container: container,
-                        modalViewController: modalViewController,
-                        onEvent: onEvent,
-                        onSizeChange: onSizeChange
-                    )
-                ))
+                self.state = .completed(root)
             default:
-                self.phase = .notFound
+                self.state = .notFound
             }
         case .failure(let err):
             switch err {
             case .notFound:
-                self.phase = .notFound
+                self.state = .notFound
             default:
-                self.phase = .failed(err)
+                self.state = .failed(err)
             }
         }
     }
@@ -239,17 +239,42 @@ struct EmbeddingSwiftView: View {
     private let experimentId: String
     private let componentId: String?
     private let container: Container
+    private let arguments: NubrickArguments?
     private let modalViewController: ModalComponentViewController?
     private let onEvent: ((_ event: ComponentEvent) -> Void)?
     private let onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
     private var fetchKey: FetchKey {
         FetchKey(experimentId: experimentId, componentId: componentId)
     }
+
+    private var phase: SwiftUIEmbeddingPhase {
+        switch data.state {
+        case .loading:
+            return .loading
+        case .completed(let root):
+            return .completed(AnyView(
+                ComponentView(
+                    root: root,
+                    container: container,
+                    arguments: arguments,
+                    modalViewController: modalViewController,
+                    onEvent: onEvent,
+                    onSizeChange: onSizeChange
+                )
+                .id(root.id)
+            ))
+        case .notFound:
+            return .notFound
+        case .failed(let error):
+            return .failed(error)
+        }
+    }
     
     init(
         experimentId: String,
         componentId: String? = nil,
         container: Container,
+        arguments: NubrickArguments? = nil,
         modalViewController: ModalComponentViewController?,
         onEvent: ((_ event: ComponentEvent) -> Void)?,
         onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
@@ -257,6 +282,7 @@ struct EmbeddingSwiftView: View {
         self.experimentId = experimentId
         self.componentId = componentId
         self.container = container
+        self.arguments = arguments
         self.modalViewController = modalViewController
         self.onEvent = onEvent
         self.onSizeChange = onSizeChange
@@ -276,6 +302,7 @@ struct EmbeddingSwiftView: View {
         experimentId: String,
         componentId: String? = nil,
         container: Container,
+        arguments: NubrickArguments? = nil,
         modalViewController: ModalComponentViewController?,
         onEvent: ((_ event: ComponentEvent) -> Void)?,
         content: @escaping ((_ phase: SwiftUIEmbeddingPhase) -> V),
@@ -284,6 +311,7 @@ struct EmbeddingSwiftView: View {
         self.experimentId = experimentId
         self.componentId = componentId
         self.container = container
+        self.arguments = arguments
         self.modalViewController = modalViewController
         self.onEvent = onEvent
         self.onSizeChange = onSizeChange
@@ -295,16 +323,13 @@ struct EmbeddingSwiftView: View {
     var body: some View {
         // ZStack provides a concrete mounted host even when phase content is EmptyView to make sure .task runs
         ZStack {
-            self._content(data.phase)
+            self._content(self.phase)
         }
             .task(id: fetchKey) {
                 await data.fetchEmbeddingAndUpdatePhase(
                     experimentId: experimentId,
                     componentId: componentId,
-                    container: container,
-                    modalViewController: modalViewController,
-                    onEvent: onEvent,
-                    onSizeChange: onSizeChange
+                    container: container
                 )
             }
     }

--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -203,6 +203,9 @@ final class PageView: UIView {
     }
 
     func update(arguments: NubrickArguments?) {
+        guard self.arguments != nil || arguments != nil else {
+            return
+        }
         self.arguments = arguments
         self.variableStore.update(self.createVariable())
     }

--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -100,7 +100,9 @@ final class PageView: UIView {
     fileprivate let page: UIPageBlock?
     private let props: [Property]?
     private let container: Container
-    private var data: Variable? = nil
+    private var arguments: NubrickArguments?
+    private let variableStore: VariableStore
+    private var responseData: Any? = nil
     private var actionHandler: UIBlockActionHandler? = nil
     private var fullScreenInitialNavItemVisibility = false
     private var loading: Bool = false
@@ -108,7 +110,7 @@ final class PageView: UIView {
 
     private var modalViewController: ModalComponentViewController? = nil
 
-    @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(page:props:container:actionHandler:modalViewController:).")
+    @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(page:props:container:arguments:actionHandler:modalViewController:).")
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -117,35 +119,36 @@ final class PageView: UIView {
         page: UIPageBlock?,
         props: [Property]?,
         container: Container,
+        arguments: NubrickArguments?,
         actionHandler: UIBlockActionHandler?,
         modalViewController: ModalComponentViewController?
     ) {
         self.page = page
         self.container = container
+        self.arguments = arguments
         self.modalViewController = modalViewController
 
         // build placeholder input. init.props is passed from other pages, and page.data.props are the page.props.
         // so merge them and create self.props.
         self.props = Self.mergeProps(pageProps: page?.data?.props, actionProps: props)
-
-        self.data = container.createVariableForTemplate(data: nil, properties: self.props)
+        self.variableStore = VariableStore(container.createVariableForTemplate(
+            data: nil,
+            properties: self.props,
+            arguments: arguments
+        ))
         super.init(frame: .zero)
 
-        let parentActionHandler = actionHandler
         self.actionHandler = { [weak self] action, onHttpSettled in
             guard let self else {
                 return
             }
 
-            let variable = _mergeVariable(
-                base: self.data,
-                self.container.createVariableForTemplate(data: nil, properties: self.props)
-            )
+            let variable = self.currentVariable()
 
             let assertion = action.httpResponseAssertion
             let forwardAction = { () -> Void in
                 Task { @MainActor in
-                    parentActionHandler?(action, nil)
+                    actionHandler?(action, nil)
                 }
             }
 
@@ -195,6 +198,15 @@ final class PageView: UIView {
         self.actionHandler?(action, nil)
     }
 
+    func currentVariable() -> Variable? {
+        self.variableStore.variable
+    }
+
+    func update(arguments: NubrickArguments?) {
+        self.arguments = arguments
+        self.variableStore.update(self.createVariable())
+    }
+
     @available(*, deprecated, renamed: "dispatchAction(_:)")
     func dispatch(action: UIBlockAction) {
         self.dispatchAction(action)
@@ -213,22 +225,28 @@ final class PageView: UIView {
 
         Task {
             let variable = self.container.createVariableForTemplate(
-                data: nil, properties: self.props)
+                data: nil,
+                properties: self.props,
+                arguments: self.arguments
+            )
             let result = await self.container.sendHttpRequest(
                 req: httpRequest,
                 assertion: nil,
                 variable: variable
             )
             await MainActor.run { [weak self] in
+                guard let self else {
+                    return
+                }
                 switch result {
                 case .success(let response):
-                    self?.data = self?.container.createVariableForTemplate(
-                        data: response.data?.value, properties: self?.props)
+                    self.responseData = response.data?.value
+                    self.variableStore.update(self.createVariable())
                 default:
                     break
                 }
-                self?.loading = false
-                self?.renderView()
+                self.loading = false
+                self.renderView()
             }
         }
     }
@@ -241,8 +259,9 @@ final class PageView: UIView {
                 context: UIBlockContext(
                     UIBlockContextInit(
                         container: self.container,
-                        variable: self.data,
+                        variableStore: self.variableStore,
                         actionHandler: self.actionHandler,
+                        layoutInvalidationRoot: self,
                         loading: self.loading
                     )
                 ),
@@ -306,5 +325,13 @@ final class PageView: UIView {
                 ptype: property.ptype ?? PropertyType.STRING
             )
         }
+    }
+
+    private func createVariable() -> Variable? {
+        self.container.createVariableForTemplate(
+            data: self.responseData,
+            properties: self.props,
+            arguments: self.arguments
+        )
     }
 }

--- a/Sources/Nubrick/Component/renderer/background-image-observer.swift
+++ b/Sources/Nubrick/Component/renderer/background-image-observer.swift
@@ -1,0 +1,22 @@
+import Combine
+import UIKit
+
+@MainActor
+protocol BackgroundImageObserver: UIView {
+    var cancellables: Set<AnyCancellable> { get set }
+    var backgroundImageLoadTask: Task<Void, Never>? { get set }
+}
+
+extension BackgroundImageObserver {
+    func observeBackgroundImage(context: UIBlockContext, urlTemplate: String) {
+        context.variablePublisher()
+            .map { compile(urlTemplate, $0) }
+            .removeDuplicates()
+            .sink { [weak self] src in
+                guard let self else { return }
+                self.backgroundImageLoadTask?.cancel()
+                self.backgroundImageLoadTask = loadAsyncImageToBackgroundSrc(url: src, view: self)
+            }
+            .store(in: &self.cancellables)
+    }
+}

--- a/Sources/Nubrick/Component/renderer/background-image-observer.swift
+++ b/Sources/Nubrick/Component/renderer/background-image-observer.swift
@@ -9,6 +9,12 @@ protocol BackgroundImageObserver: UIView {
 
 extension BackgroundImageObserver {
     func observeBackgroundImage(context: UIBlockContext, urlTemplate: String) {
+        guard hasPlaceholderPath(template: urlTemplate) else {
+            self.backgroundImageLoadTask?.cancel()
+            self.backgroundImageLoadTask = loadAsyncImageToBackgroundSrc(url: urlTemplate, view: self)
+            return
+        }
+
         context.variablePublisher()
             .map { compile(urlTemplate, $0) }
             .removeDuplicates()

--- a/Sources/Nubrick/Component/renderer/collection.swift
+++ b/Sources/Nubrick/Component/renderer/collection.swift
@@ -334,15 +334,15 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
                     return cell
                 }
                 let item = indexPath.item
-                let variable = self.context.getVariable()
-                let data = Self.referencedItems(reference: reference, variable: variable)
-                let childData: Any = data.indices.contains(item) ? data[item] : ([:] as [String: Any])
-                let childVariable = _mergeVariable(base: variable, Variable(value: ["data": childData]))
                 let childView = UIViewBlock(
                     data: child,
                     context: self.context.instanciateFrom(
                         UIBlockContextChildInit(
-                            variable: childVariable,
+                            variableMapper: { variable in
+                                let data = Self.referencedItems(reference: reference, variable: variable)
+                                let childData: Any = data.indices.contains(item) ? data[item] : ([:] as [String: Any])
+                                return _replaceVariableData(base: variable, data: childData)
+                            },
                             parentClickListener: self.gesture,
                             parentDirection: self.block?.data?.direction,
                             layoutInvalidationRoot: cell

--- a/Sources/Nubrick/Component/renderer/collection.swift
+++ b/Sources/Nubrick/Component/renderer/collection.swift
@@ -5,6 +5,7 @@
 //  Created by Ryosuke Suzuki on 2023/03/31.
 //
 
+import Combine
 import Foundation
 import UIKit
 internal import YogaKit
@@ -101,12 +102,11 @@ fileprivate func getCollectionLayout(_ block: UICollectionBlock) -> UICollection
     }
 }
 
-class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, BackgroundImageObserver {
     private let block: UICollectionBlock?
     private let context: UIBlockContext
     private var childrenCount: Int = 0
     private var isReferenced: Bool = false
-    private var data: [Any]? = nil
     private var gesture: ClickListener? = nil
     private var pageControl: UIPageControl? = nil
     private var collectionView: UICollectionView? = nil
@@ -118,28 +118,24 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
     private let formValueListenerInstanceId = UUID().uuidString
     private var formValueListener: FormValueListener?
     private var hasRegisteredFormValueListener = false
+    var cancellables = Set<AnyCancellable>()
+    var backgroundImageLoadTask: Task<Void, Never>?
     
     required init?(coder aDecoder: NSCoder) {
         self.block = nil
         self.context = UIBlockContext(UIBlockContextInit())
         self.childrenCount = 0
         self.isReferenced = false
-        self.data = nil
         super.init(coder: aDecoder)
     }
     
     init(block: UICollectionBlock, context: UIBlockContext) {
         self.block = block
         self.context = context
+        self.isReferenced = block.data?.reference != nil
         if let reference = block.data?.reference {
-            if let data = context.getArrayByReferenceKey(key: reference) {
-                self.childrenCount = data.count
-                self.isReferenced = true
-                self.data = data
-            }
-        }
-
-        if !self.isReferenced {
+            self.childrenCount = Self.referencedItems(reference: reference, variable: context.getVariable()).count
+        } else {
             self.childrenCount = block.data?.children?.count ?? 0
         }
 
@@ -213,6 +209,36 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
             self.formValueListenerId = "\(id)::\(self.formValueListenerInstanceId)"
             self.formValueListener = handleDisabled
         }
+
+        self.bindVariable()
+    }
+
+    private func bindVariable() {
+        if let reference = self.block?.data?.reference {
+            self.context.variablePublisher()
+                .map { variable in
+                    Self.referencedItems(reference: reference, variable: variable).count
+                }
+                .removeDuplicates()
+                .dropFirst()
+                .sink { [weak self] childrenCount in
+                    guard let self else { return }
+                    self.childrenCount = childrenCount
+
+                    self.pageControl?.numberOfPages = self.childrenCount
+                    self.setCurrentPage(min(self.getCurrentPage(), max(0, self.childrenCount - 1)))
+                    self.collectionView?.reloadData()
+                }
+                .store(in: &self.cancellables)
+        }
+
+        if let template = self.block?.data?.frame?.backgroundSrc {
+            observeBackgroundImage(context: self.context, urlTemplate: template)
+        }
+    }
+
+    private static func referencedItems(reference: String, variable: Variable?) -> [Any] {
+        return variableByPath(path: reference, variable: variable?.value) as? [Any] ?? []
     }
 
     private func registerFormValueListenerIfNeeded() {
@@ -233,6 +259,10 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
 
         self.context.removeFormValueListener(id)
         self.hasRegisteredFormValueListener = false
+    }
+
+    deinit {
+        self.backgroundImageLoadTask?.cancel()
     }
 
     private func shouldAutoScroll() -> Bool {
@@ -286,16 +316,22 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
                 guard let child = self.block?.data?.children?[0] else {
                     return cell
                 }
-                guard let childData = self.data?[indexPath.item] else {
+                guard let reference = self.block?.data?.reference else {
                     return cell
                 }
+                let item = indexPath.item
+                let variable = self.context.getVariable()
+                let data = Self.referencedItems(reference: reference, variable: variable)
+                let childData: Any = data.indices.contains(item) ? data[item] : ([:] as [String: Any])
+                let childVariable = _mergeVariable(base: variable, Variable(value: ["data": childData]))
                 let childView = UIViewBlock(
                     data: child,
                     context: self.context.instanciateFrom(
                         UIBlockContextChildInit(
-                            childData: childData,
+                            variable: childVariable,
                             parentClickListener: self.gesture,
-                            parentDirection: self.block?.data?.direction
+                            parentDirection: self.block?.data?.direction,
+                            layoutInvalidationRoot: cell
                         )
                     )
                 )
@@ -309,7 +345,8 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
                     context: self.context.instanciateFrom(
                         UIBlockContextChildInit(
                             parentClickListener: self.gesture,
-                            parentDirection: self.block?.data?.direction
+                            parentDirection: self.block?.data?.direction,
+                            layoutInvalidationRoot: cell
                         )
                     )
                 )
@@ -329,15 +366,15 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        self.pageControl?.currentPage = getCurrentPage()
+        self.setCurrentPage(self.getCurrentPage())
     }
         
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        self.pageControl?.currentPage = getCurrentPage()
+        self.setCurrentPage(self.getCurrentPage())
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        self.pageControl?.currentPage = getCurrentPage()
+        self.setCurrentPage(self.getCurrentPage())
     }
     
     func getCurrentPage() -> Int {
@@ -353,6 +390,11 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
             return visibleIndexPath.row
         }
         return pageControl.currentPage
+    }
+
+    private func setCurrentPage(_ page: Int) {
+        self.counter = page
+        self.pageControl?.currentPage = page
     }
     
     func automaticScroll() {

--- a/Sources/Nubrick/Component/renderer/collection.swift
+++ b/Sources/Nubrick/Component/renderer/collection.swift
@@ -228,6 +228,7 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
                     self.pageControl?.numberOfPages = self.childrenCount
                     self.setCurrentPage(min(self.getCurrentPage(), max(0, self.childrenCount - 1)))
                     self.collectionView?.reloadData()
+                    self.reconcileAutoScrollTimer()
                 }
                 .store(in: &self.cancellables)
         }
@@ -287,6 +288,19 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
     private func stopAutoScrollTimer() {
         self.timer?.invalidate()
         self.timer = nil
+    }
+
+    private func reconcileAutoScrollTimer() {
+        guard self.window != nil else {
+            self.stopAutoScrollTimer()
+            return
+        }
+
+        if self.shouldAutoScroll() {
+            self.startAutoScrollTimerIfNeeded()
+        } else {
+            self.stopAutoScrollTimer()
+        }
     }
 
     override func didMoveToWindow() {

--- a/Sources/Nubrick/Component/renderer/flex.swift
+++ b/Sources/Nubrick/Component/renderer/flex.swift
@@ -5,11 +5,12 @@
 //  Created by Ryosuke Suzuki on 2023/03/28.
 //
 
+import Combine
 import Foundation
 import UIKit
 internal import YogaKit
 
-class FlexView: AnimatedUIControl {
+class FlexView: AnimatedUIControl, BackgroundImageObserver {
     private var block: UIFlexContainerBlock = UIFlexContainerBlock()
     private var context: UIBlockContext?
     private var isOverflowView = false
@@ -19,6 +20,8 @@ class FlexView: AnimatedUIControl {
     private let formValueListenerInstanceId = UUID().uuidString
     private var formValueListener: FormValueListener?
     private var hasRegisteredFormValueListener = false
+    var cancellables = Set<AnyCancellable>()
+    var backgroundImageLoadTask: Task<Void, Never>?
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -112,11 +115,10 @@ class FlexView: AnimatedUIControl {
             self.addSubview(child)
         }
 
-        if childFlexShrink == nil {
-            if let bgSrc = block.data?.frame?.backgroundSrc {
-                let bgSrc = compile(bgSrc, context.getVariable())
-                loadAsyncImageToBackgroundSrc(url: bgSrc, view: self)
-            }
+        if childFlexShrink == nil,
+           let context = self.context,
+           let template = self.block.data?.frame?.backgroundSrc {
+            observeBackgroundImage(context: context, urlTemplate: template)
         }
         
         let handleDisabled = makeDisabledStateListener(
@@ -152,6 +154,10 @@ class FlexView: AnimatedUIControl {
         self.hasRegisteredFormValueListener = false
     }
 
+    deinit {
+        self.backgroundImageLoadTask?.cancel()
+    }
+
     override func didMoveToWindow() {
         super.didMoveToWindow()
         if self.window == nil {
@@ -183,10 +189,11 @@ class FlexView: AnimatedUIControl {
         if !self.respectSafeArea { return }
         if newSuperview == nil { hasActivatedConstraints = false }
     }
+
 }
 
 // FlexOverflowView creates a scrollable view and contains FlexView inside as a child.
-class FlexOverflowView: UIScrollView {
+class FlexOverflowView: UIScrollView, BackgroundImageObserver {
     private var flexView: UIView = UIView()
     private var block: UIFlexContainerBlock = UIFlexContainerBlock()
     private var context: UIBlockContext?
@@ -194,7 +201,9 @@ class FlexOverflowView: UIScrollView {
     private let formValueListenerInstanceId = UUID().uuidString
     private var formValueListener: FormValueListener?
     private var hasRegisteredFormValueListener = false
-    
+    var cancellables = Set<AnyCancellable>()
+    var backgroundImageLoadTask: Task<Void, Never>?
+
     required init?(coder aDecoder: NSCoder) {
         self.context = nil
         super.init(coder: aDecoder)
@@ -258,9 +267,9 @@ class FlexOverflowView: UIScrollView {
         self.flexView = flexView
         self.addSubview(flexView)
 
-        if let bgSrc = block.data?.frame?.backgroundSrc {
-            let bgSrc = compile(bgSrc, context.getVariable())
-            loadAsyncImageToBackgroundSrc(url: bgSrc, view: self)
+        if let context = self.context,
+           let template = self.block.data?.frame?.backgroundSrc {
+            observeBackgroundImage(context: context, urlTemplate: template)
         }
         
         let handleDisabled = makeDisabledStateListener(
@@ -294,6 +303,10 @@ class FlexOverflowView: UIScrollView {
 
         self.context?.removeFormValueListener(id)
         self.hasRegisteredFormValueListener = false
+    }
+
+    deinit {
+        self.backgroundImageLoadTask?.cancel()
     }
 
     override func didMoveToWindow() {
@@ -331,4 +344,5 @@ class FlexOverflowView: UIScrollView {
         self.contentSize = self.flexView.bounds.size
         configureBorder(view: self, frame: self.block.data?.frame)
     }
+
 }

--- a/Sources/Nubrick/Component/renderer/forms.swift
+++ b/Sources/Nubrick/Component/renderer/forms.swift
@@ -151,13 +151,6 @@ class TextInputView: UIView, UITextFieldDelegate {
             }
         }
 
-        // wrap layout
-        self.configureLayout { layout in
-            layout.isEnabled = true
-            layout.width = .init(value: 100.0, unit: .percent)
-            layout.flexShrink = 1
-        }
-
         // toolbar for input
         let toolbar = UIToolbar()
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
@@ -173,9 +166,26 @@ class TextInputView: UIView, UITextFieldDelegate {
         textInput.textAlignment = parseTextAlign(block.data?.textAlign)
         textInput.inputAccessoryView = toolbar
         textInput.delegate = self
+        let font = parseTextBlockDataToUIFont(block.data?.size, block.data?.weight, block.data?.design)
+        textInput.font = font
+        let intrinsicHeight = ceil(textInput.intrinsicContentSize.height)
+        let verticalPadding = CGFloat((block.data?.frame?.paddingTop ?? 0) + (block.data?.frame?.paddingBottom ?? 0))
+
+        // wrap layout
+        self.configureLayout { layout in
+            layout.isEnabled = true
+            layout.width = .init(value: 100.0, unit: .percent)
+            configureSize(layout: layout, frame: block.data?.frame, parentDirection: context.getParentDireciton())
+            if block.data?.frame?.height == nil {
+                layout.height = .init(value: Float(intrinsicHeight + verticalPadding), unit: .point)
+            }
+            layout.flexShrink = 1
+        }
+
         textInput.configureLayout { layout in
             layout.isEnabled = true
             layout.width = .init(value: 100.0, unit: .percent)
+            layout.height = .init(value: 100.0, unit: .percent)
             configurePadding(layout: layout, frame: block.data?.frame)
         }
         if let paddingLeft = block.data?.frame?.paddingLeft {
@@ -192,7 +202,6 @@ class TextInputView: UIView, UITextFieldDelegate {
         } else {
             textInput.textColor = .label
         }
-        textInput.font = parseTextBlockDataToUIFont(block.data?.size, block.data?.weight, block.data?.design)
         self.fontSize = block.data?.size
         if let placeholder = block.data?.placeholder {
             textInput.placeholder = placeholder

--- a/Sources/Nubrick/Component/renderer/image.swift
+++ b/Sources/Nubrick/Component/renderer/image.swift
@@ -5,6 +5,7 @@
 //  Created by Ryosuke Suzuki on 2023/03/28.
 //
 
+import Combine
 import Foundation
 import UIKit
 internal import YogaKit
@@ -17,6 +18,8 @@ class ImageView: AnimatedUIControl {
     private let formValueListenerInstanceId = UUID().uuidString
     private var formValueListener: FormValueListener?
     private var hasRegisteredFormValueListener = false
+    private var cancellables = Set<AnyCancellable>()
+    private var imageLoadTask: Task<Void, Never>?
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -38,15 +41,6 @@ class ImageView: AnimatedUIControl {
             configureSkelton(view: self, showSkelton: showSkelton)
         }
 
-        let compiledSrc = compile(block.data?.src ?? "", context.getVariable())
-
-        let fallbackSetting = parseImageFallbackToBlurhash(compiledSrc)
-        let fallback = fallbackSetting.blurhash == "" ? UIImage() : UIImage(
-            blurHash: fallbackSetting.blurhash,
-            size: CGSize(width: CGFloat(fallbackSetting.width), height: CGFloat(fallbackSetting.height))
-        )
-        self.image.image = fallback
-
         self.image.configureLayout { layout in
             layout.isEnabled = true
 
@@ -64,6 +58,7 @@ class ImageView: AnimatedUIControl {
         self.layer.masksToBounds = true
 
         self.addSubview(self.image)
+        self.bindVariable()
 
         _ = configureOnClickGesture(
             target: self,
@@ -72,8 +67,6 @@ class ImageView: AnimatedUIControl {
             uiBlockAction: block.data?.onClick
         )
 
-        loadAsyncImage(url: compiledSrc, view: self, image: self.image)
-        
         let handleDisabled = makeDisabledStateListener(
             target: self,
             context: context,
@@ -107,6 +100,10 @@ class ImageView: AnimatedUIControl {
         self.hasRegisteredFormValueListener = false
     }
 
+    deinit {
+        self.imageLoadTask?.cancel()
+    }
+
     override func didMoveToWindow() {
         super.didMoveToWindow()
 
@@ -121,12 +118,41 @@ class ImageView: AnimatedUIControl {
         super.layoutSubviews()
         configureBorder(view: self, frame: self.block.data?.frame)
     }
+
+    private func bindVariable() {
+        guard let context = self.context else {
+            return
+        }
+
+        let srcTemplate = self.block.data?.src ?? ""
+        context.variablePublisher()
+            .map { compile(srcTemplate, $0) }
+            .removeDuplicates()
+            .sink { [weak self] src in
+                self?.applyImageSource(src)
+            }
+            .store(in: &self.cancellables)
+    }
+
+    private func applyImageSource(_ src: String) {
+        let fallbackSetting = parseImageFallbackToBlurhash(src)
+        self.image.image = fallbackSetting.blurhash == "" ? UIImage() : UIImage(
+            blurHash: fallbackSetting.blurhash,
+            size: CGSize(width: CGFloat(fallbackSetting.width), height: CGFloat(fallbackSetting.height))
+        )
+        self.imageLoadTask?.cancel()
+        self.imageLoadTask = loadAsyncImage(
+            url: src,
+            image: self.image,
+            layoutRoot: self.context?.getLayoutInvalidationRoot()
+        )
+    }
 }
 
 @MainActor
-func loadAsyncImageToBackgroundSrc(url: String, view: UIView) {
+func loadAsyncImageToBackgroundSrc(url: String, view: UIView) -> Task<Void, Never>? {
     guard let requestUrl = URL(string: url) else {
-        return
+        return nil
     }
     
     let fallbackSetting = parseImageFallbackToBlurhash(url)
@@ -141,11 +167,15 @@ func loadAsyncImageToBackgroundSrc(url: String, view: UIView) {
         view.clipsToBounds = true
     }
     
-    Task {
+    return Task {
         do {
             let (data, response) = try await nativebrikSession.data(from: requestUrl)
+            try Task.checkCancellation()
             
             await MainActor.run {
+                guard !Task.isCancelled else {
+                    return
+                }
                 if isGif(response) {
                     guard let image = UIImage.gifImageWithData(data) else {
                         return
@@ -173,8 +203,8 @@ func loadAsyncImageToBackgroundSrc(url: String, view: UIView) {
                         },
                         completion: nil)
                 }
-                view.layoutSubviews()
             }
+        } catch is CancellationError {
         } catch {
             // Error handling - silently fail as before
             print("Failed to load image from \(url): \(error)")
@@ -183,16 +213,20 @@ func loadAsyncImageToBackgroundSrc(url: String, view: UIView) {
 }
 
 @MainActor
-func loadAsyncImage(url: String, view: UIView, image: UIImageView) {
+func loadAsyncImage(url: String, image: UIImageView, layoutRoot: UIView?) -> Task<Void, Never>? {
     guard let requestUrl = URL(string: url) else {
-        return
+        return nil
     }
     
-    Task {
+    return Task {
         do {
             let (data, response) = try await nativebrikSession.data(from: requestUrl)
+            try Task.checkCancellation()
             
             await MainActor.run {
+                guard !Task.isCancelled else {
+                    return
+                }
                 if isGif(response) {
                     UIView.transition(
                         with: image,
@@ -212,8 +246,11 @@ func loadAsyncImage(url: String, view: UIView, image: UIImageView) {
                         },
                         completion: nil)
                 }
-                view.layoutSubviews()
+                if let layoutRoot {
+                    invalidateYogaLayout(from: image, layoutRoot: layoutRoot)
+                }
             }
+        } catch is CancellationError {
         } catch {
             // Error handling - silently fail as before
             print("Failed to load image from \(url): \(error)")

--- a/Sources/Nubrick/Component/renderer/image.swift
+++ b/Sources/Nubrick/Component/renderer/image.swift
@@ -156,20 +156,18 @@ class ImageView: AnimatedUIControl {
 
 @MainActor
 func loadAsyncImageToBackgroundSrc(url: String, view: UIView) -> Task<Void, Never>? {
-    guard let requestUrl = URL(string: url) else {
-        return nil
-    }
-    
     let fallbackSetting = parseImageFallbackToBlurhash(url)
     let fallback = fallbackSetting.blurhash == "" ? UIImage() : UIImage(
         blurHash: fallbackSetting.blurhash,
         size: CGSize(width: CGFloat(fallbackSetting.width), height: CGFloat(fallbackSetting.height))
     )
-    
-    if let fallback = fallback {
-        view.layer.contents = fallback.cgImage
-        view.contentMode = UIView.ContentMode.scaleAspectFill
-        view.clipsToBounds = true
+
+    view.layer.contents = fallback?.cgImage
+    view.contentMode = UIView.ContentMode.scaleAspectFill
+    view.clipsToBounds = true
+
+    guard let requestUrl = URL(string: url) else {
+        return nil
     }
     
     return Task {

--- a/Sources/Nubrick/Component/renderer/image.swift
+++ b/Sources/Nubrick/Component/renderer/image.swift
@@ -125,6 +125,11 @@ class ImageView: AnimatedUIControl {
         }
 
         let srcTemplate = self.block.data?.src ?? ""
+        guard hasPlaceholderPath(template: srcTemplate) else {
+            self.applyImageSource(srcTemplate)
+            return
+        }
+
         context.variablePublisher()
             .map { compile(srcTemplate, $0) }
             .removeDuplicates()

--- a/Sources/Nubrick/Component/renderer/modal-component.swift
+++ b/Sources/Nubrick/Component/renderer/modal-component.swift
@@ -98,15 +98,21 @@ class ModalComponentViewController: UIViewController {
 class ModalBackButtonBehaviorDelegate: NSObject, SFSafariViewControllerDelegate {
     private let actionEvent: UIBlockAction?
     private let context: UIBlockContext
+    private let variableProvider: @MainActor () -> Variable?
 
-    init(event: UIBlockAction?, context: UIBlockContext) {
+    init(
+        event: UIBlockAction?,
+        context: UIBlockContext,
+        variableProvider: @escaping @MainActor () -> Variable? = { nil }
+    ) {
         self.actionEvent = event
         self.context = context
+        self.variableProvider = variableProvider
     }
 
     func onBackButtonClick() {
         guard let actionEvent else { return }
-        let compiledAction = compileAction(action: actionEvent, context: context)
+        let compiledAction = compileAction(action: actionEvent, variable: variableProvider())
         context.dispatch(action: compiledAction)
     }
 

--- a/Sources/Nubrick/Component/renderer/text.swift
+++ b/Sources/Nubrick/Component/renderer/text.swift
@@ -115,19 +115,23 @@ class TextView: AnimatedUIControl, BackgroundImageObserver {
         }
 
         let textTemplate = self.block.data?.value ?? ""
-        var shouldInvalidateLayout = false
-        context.variablePublisher()
-            .map { compile(textTemplate, $0) }
-            .removeDuplicates()
-            .sink { [weak self] text in
-                guard let self else { return }
-                self.label.text = text
-                if shouldInvalidateLayout {
-                    invalidateYogaLayout(from: self.label, layoutRoot: context.getLayoutInvalidationRoot())
+        if hasPlaceholderPath(template: textTemplate) {
+            var shouldInvalidateLayout = false
+            context.variablePublisher()
+                .map { compile(textTemplate, $0) }
+                .removeDuplicates()
+                .sink { [weak self] text in
+                    guard let self else { return }
+                    self.label.text = text
+                    if shouldInvalidateLayout {
+                        invalidateYogaLayout(from: self.label, layoutRoot: context.getLayoutInvalidationRoot())
+                    }
+                    shouldInvalidateLayout = true
                 }
-                shouldInvalidateLayout = true
-            }
-            .store(in: &self.cancellables)
+                .store(in: &self.cancellables)
+        } else {
+            self.label.text = textTemplate
+        }
 
         if let template = self.block.data?.frame?.backgroundSrc {
             observeBackgroundImage(context: context, urlTemplate: template)

--- a/Sources/Nubrick/Component/renderer/text.swift
+++ b/Sources/Nubrick/Component/renderer/text.swift
@@ -1,7 +1,8 @@
+import Combine
 import Foundation
 import UIKit
 
-class TextView: AnimatedUIControl {
+class TextView: AnimatedUIControl, BackgroundImageObserver {
     var label: UILabel = UILabel()
     var block: UITextBlock = UITextBlock()
     var context: UIBlockContext?
@@ -9,6 +10,8 @@ class TextView: AnimatedUIControl {
     private let formValueListenerInstanceId = UUID().uuidString
     private var formValueListener: FormValueListener?
     private var hasRegisteredFormValueListener = false
+    var cancellables = Set<AnyCancellable>()
+    var backgroundImageLoadTask: Task<Void, Never>?
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -36,8 +39,6 @@ class TextView: AnimatedUIControl {
             label.textColor = .label
         }
         label.font = parseTextBlockDataToUIFont(block.data?.size, block.data?.weight, block.data?.design)
-        let text = compile(block.data?.value ?? "", context.getVariable())
-        label.text = text
         if let maxLines = block.data?.maxLines {
             label.numberOfLines = maxLines
         } else {
@@ -47,6 +48,7 @@ class TextView: AnimatedUIControl {
         
         self.label = label
         self.addSubview(label)
+        self.bindVariable()
         
         _ = configureOnClickGesture(
             target: self,
@@ -54,11 +56,6 @@ class TextView: AnimatedUIControl {
             context: context,
             uiBlockAction: block.data?.onClick
         )
-        
-        if let bgSrc = block.data?.frame?.backgroundSrc {
-            let bgSrc = compile(bgSrc, context.getVariable())
-            loadAsyncImageToBackgroundSrc(url: bgSrc, view: self)
-        }
         
         let handleDisabled = makeDisabledStateListener(
             target: self,
@@ -93,6 +90,10 @@ class TextView: AnimatedUIControl {
         self.hasRegisteredFormValueListener = false
     }
 
+    deinit {
+        self.backgroundImageLoadTask?.cancel()
+    }
+
     override func didMoveToWindow() {
         super.didMoveToWindow()
 
@@ -106,5 +107,30 @@ class TextView: AnimatedUIControl {
     override func layoutSubviews() {
         super.layoutSubviews()
         configureBorder(view: self, frame: self.block.data?.frame)
+    }
+
+    private func bindVariable() {
+        guard let context = self.context else {
+            return
+        }
+
+        let textTemplate = self.block.data?.value ?? ""
+        var shouldInvalidateLayout = false
+        context.variablePublisher()
+            .map { compile(textTemplate, $0) }
+            .removeDuplicates()
+            .sink { [weak self] text in
+                guard let self else { return }
+                self.label.text = text
+                if shouldInvalidateLayout {
+                    invalidateYogaLayout(from: self.label, layoutRoot: context.getLayoutInvalidationRoot())
+                }
+                shouldInvalidateLayout = true
+            }
+            .store(in: &self.cancellables)
+
+        if let template = self.block.data?.frame?.backgroundSrc {
+            observeBackgroundImage(context: context, urlTemplate: template)
+        }
     }
 }

--- a/Sources/Nubrick/Component/root.swift
+++ b/Sources/Nubrick/Component/root.swift
@@ -26,7 +26,7 @@ class ModalRootViewController: UIViewController {
         }
         self.modalViewController = modalViewController
         self.modalViewController?.dismissModal()
-        self.container = container
+        self.container = container.makeContainer()
         super.init(nibName: nil, bundle: nil)
 
         self.actionHandler = { [weak self] action, _ in
@@ -40,7 +40,7 @@ class ModalRootViewController: UIViewController {
         }
 
         if let onTrigger = trigger?.data?.triggerSetting?.onTrigger {
-            self.actionHandler?(onTrigger, nil)
+            self.actionHandler?(compileAction(action: onTrigger, variable: self.rootVariable()), nil)
         }
     }
 
@@ -75,8 +75,11 @@ class ModalRootViewController: UIViewController {
         // when it's webview modal
         if page?.data?.kind == PageKind.WEBVIEW_MODAL {
             let onBackButtonClick = page?.data?.triggerSetting?.onTrigger
+            let variableProvider: @MainActor () -> Variable? = { [weak self] in
+                self?.rootVariable()
+            }
             self.modalViewController?.presentWebview(
-                url: page?.data?.webviewUrl,
+                url: page?.data?.webviewUrl.map { compile($0, variableProvider()) },
                 backButtonBehaviorDelegate: (onBackButtonClick != nil) ? ModalBackButtonBehaviorDelegate(
                     event: onBackButtonClick,
                     context: UIBlockContext(
@@ -84,7 +87,8 @@ class ModalRootViewController: UIViewController {
                             container: self.container,
                             actionHandler: self.actionHandler
                         )
-                    )
+                    ),
+                    variableProvider: variableProvider
                 ) : nil
             )
             return
@@ -94,6 +98,7 @@ class ModalRootViewController: UIViewController {
             page: page,
             props: props,
             container: self.container,
+            arguments: nil,
             actionHandler: self.actionHandler,
             modalViewController: self.modalViewController
         )
@@ -112,7 +117,8 @@ class ModalRootViewController: UIViewController {
                             container: self.container,
                             actionHandler: self.actionHandler
                         )
-                    )
+                    ),
+                    variableProvider: { [weak pageView] in pageView?.currentVariable() }
                 ) : nil
             )
             break
@@ -121,12 +127,17 @@ class ModalRootViewController: UIViewController {
             break
         }
     }
+
+    private func rootVariable() -> Variable? {
+        self.container.createVariableForTemplate(data: nil, properties: nil, arguments: nil)
+    }
 }
 
 struct RootViewRepresentable: UIViewRepresentable {
     typealias UIViewType = RootView
     let root: UIRootBlock?
     let container: Container
+    let arguments: NubrickArguments?
     let modalViewController: ModalComponentViewController?
     let onEvent: ((_ action: UIBlockAction) -> Void)?
     let onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
@@ -168,18 +179,24 @@ struct RootViewRepresentable: UIViewRepresentable {
 
 
     func makeUIView(context: Self.Context) -> Self.UIViewType {
-        let onSizeChange: (NubrickSize, NubrickSize) -> Void = { [weak coordinator = context.coordinator] w, h in
+        let reportSizeChange: (NubrickSize, NubrickSize) -> Void = { [weak coordinator = context.coordinator] w, h in
             Task { @MainActor in
                 coordinator?.report(width: w, height: h)
             }
         }
         return RootView(
-            root: root, container: container, modalViewController: modalViewController,
-            onEvent: onEvent, onSizeChange: onSizeChange)
+            root: root,
+            container: container,
+            arguments: arguments,
+            modalViewController: modalViewController,
+            onEvent: onEvent,
+            onSizeChange: reportSizeChange
+        )
     }
 
     // Update the wrapped UIView when SwiftUI state changes.
     func updateUIView(_ uiView: Self.UIViewType, context: Self.Context) {
+        uiView.update(arguments: arguments, onEvent: onEvent)
         context.coordinator.onSizeChange = onSizeChange
     }
 
@@ -201,11 +218,13 @@ class RootView: UIView {
     private var view: UIView? = nil
     private var currentPageView: PageView? = nil
     private var modalViewController: ModalComponentViewController? = nil
-    private let container: Container
+    private var container: Container
+    private var arguments: NubrickArguments?
+    private var onEvent: ((_ action: UIBlockAction) -> Void)?
     // callback to transmit size to SwiftUI
     var onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
 
-    @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(root:container:modalViewController:onEvent:onNextTooltip:onDismiss:onSizeChange:).")
+    @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(root:container:arguments:modalViewController:onEvent:onNextTooltip:onDismiss:onSizeChange:).")
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -213,6 +232,7 @@ class RootView: UIView {
     init(
         root: UIRootBlock?,
         container: Container,
+        arguments: NubrickArguments? = nil,
         modalViewController: ModalComponentViewController?,
         onEvent: ((_ action: UIBlockAction) -> Void)?,
         onNextTooltip: ((_ pageId: String) -> Void)? = nil,
@@ -220,12 +240,14 @@ class RootView: UIView {
         onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
         self.id = root?.id ?? ""
-        self.container = container
+        self.container = container.makeContainer()
+        self.arguments = arguments
         self.pages = root?.data?.pages ?? []
         let trigger = self.pages.first { page in
             return page.data?.kind == PageKind.TRIGGER
         }
         self.modalViewController = modalViewController
+        self.onEvent = onEvent
         self.onNextTooltip = onNextTooltip ?? { _ in }
         self.onDismiss = onDismiss ?? {}
         self.onSizeChange = onSizeChange
@@ -243,11 +265,11 @@ class RootView: UIView {
                 self.presentPage(pageId: destinationPageId, props: action.payload)
             }
             self.container.handleEvent(action)
-            onEvent?(action)
+            self.onEvent?(action)
         }
 
         if let onTrigger = trigger?.data?.triggerSetting?.onTrigger {
-            self.actionHandler?(onTrigger, nil)
+            self.actionHandler?(compileAction(action: onTrigger, variable: self.rootVariable()), nil)
         }
     }
 
@@ -258,6 +280,15 @@ class RootView: UIView {
         } else {
             self.actionHandler?(action, nil)
         }
+    }
+
+    func update(
+        arguments: NubrickArguments?,
+        onEvent: ((_ action: UIBlockAction) -> Void)?
+    ) {
+        self.arguments = arguments
+        self.onEvent = onEvent
+        self.currentPageView?.update(arguments: arguments)
     }
 
     @available(*, deprecated, renamed: "dispatchAction(_:)")
@@ -297,8 +328,11 @@ class RootView: UIView {
         // when it's webview modal
         if page?.data?.kind == PageKind.WEBVIEW_MODAL {
             let onBackButtonClick = page?.data?.triggerSetting?.onTrigger
+            let variableProvider: @MainActor () -> Variable? = { [weak self] in
+                self?.rootVariable()
+            }
             self.modalViewController?.presentWebview(
-                url: page?.data?.webviewUrl,
+                url: page?.data?.webviewUrl.map { compile($0, variableProvider()) },
                 backButtonBehaviorDelegate: (onBackButtonClick != nil) ? ModalBackButtonBehaviorDelegate(
                     event: onBackButtonClick,
                     context: UIBlockContext(
@@ -306,7 +340,8 @@ class RootView: UIView {
                             container: self.container,
                             actionHandler: self.actionHandler
                         )
-                    )
+                    ),
+                    variableProvider: variableProvider
                 ) : nil
             )
             return
@@ -319,10 +354,19 @@ class RootView: UIView {
             self.currentTooltipAnchorId = anchorId
         }
 
+        if page?.data?.kind != .MODAL {
+            self.modalViewController?.dismissModal()
+            if self.currentEmbeddedPageId == currentPageId {
+                self.currentPageView?.update(arguments: self.arguments)
+                return
+            }
+        }
+
         let pageView = PageView(
             page: page,
             props: props,
             container: self.container,
+            arguments: self.arguments,
             actionHandler: self.actionHandler,
             modalViewController: self.modalViewController
         )
@@ -342,7 +386,8 @@ class RootView: UIView {
                             container: self.container,
                             actionHandler: self.actionHandler
                         )
-                    )
+                    ),
+                    variableProvider: { [weak pageView] in pageView?.currentVariable() }
                 ) : nil
             )
         case .COMPONENT:
@@ -354,10 +399,6 @@ class RootView: UIView {
             self.onSizeChange?(width, height)
             fallthrough
         default:
-            self.modalViewController?.dismissModal()
-            if self.currentEmbeddedPageId == currentPageId {
-                return
-            }
             self.view?.removeFromSuperview()
             self.view = pageView
             self.addSubview(pageView)
@@ -366,6 +407,14 @@ class RootView: UIView {
             self.superview?.invalidateIntrinsicContentSize() // we need to invalidate intrinsic for the EmbeddingUIView for relayout
             break
         }
+    }
+
+    private func rootVariable() -> Variable? {
+        self.container.createVariableForTemplate(
+            data: nil,
+            properties: nil,
+            arguments: self.arguments
+        )
     }
 
     override func layoutSubviews() {

--- a/Sources/Nubrick/Component/trigger.swift
+++ b/Sources/Nubrick/Component/trigger.swift
@@ -154,7 +154,7 @@ class TriggerViewController: UIViewController {
                         } else {
                             let root = ModalRootViewController(
                                 root: root,
-                                container: self.container.makeContainer(arguments: nil),
+                                container: self.container,
                                 modalViewController: self.modalViewController
                             )
                             if let currentVC = self.currentVC {

--- a/Sources/Nubrick/Data/container.swift
+++ b/Sources/Nubrick/Data/container.swift
@@ -17,9 +17,9 @@ protocol Container : Sendable {
     @MainActor
     func handleEvent(_ it: UIBlockAction)
     @MainActor
-    func makeContainer(arguments: NubrickArguments?) -> Container
+    func makeContainer() -> Container
     @MainActor
-    func createVariableForTemplate(data: Any?, properties: [Property]?) -> Variable?
+    func createVariableForTemplate(data: Any?, properties: [Property]?, arguments: NubrickArguments?) -> Variable?
     @MainActor
     func getFormValue(key: String) -> Any?
     @MainActor
@@ -47,7 +47,6 @@ final class ContainerImpl: Container {
     private let databaseRepository: DatabaseRepository
     private let httpRequestRepository: HttpRequestRepository
     private let formRepository: FormRepository
-    private let arguments: NubrickArguments?
 
     @MainActor
     init(
@@ -58,8 +57,7 @@ final class ContainerImpl: Container {
         componentRepository: ComponentRepository2,
         trackRepository: TrackRepository2,
         databaseRepository: DatabaseRepository,
-        httpRequestRepository: HttpRequestRepository,
-        arguments: NubrickArguments? = nil
+        httpRequestRepository: HttpRequestRepository
     ) {
         self.config = config
         self.user = user
@@ -70,7 +68,6 @@ final class ContainerImpl: Container {
         self.databaseRepository = databaseRepository
         self.httpRequestRepository = httpRequestRepository
         self.formRepository = FormRepositoryImpl()
-        self.arguments = arguments
     }
 
     @MainActor
@@ -79,7 +76,7 @@ final class ContainerImpl: Container {
     }
 
     @MainActor
-    func makeContainer(arguments: NubrickArguments?) -> Container {
+    func makeContainer() -> Container {
         return ContainerImpl(
             config: self.config,
             user: self.user,
@@ -88,19 +85,18 @@ final class ContainerImpl: Container {
             componentRepository: self.componentRepository,
             trackRepository: self.trackRepository,
             databaseRepository: self.databaseRepository,
-            httpRequestRepository: self.httpRequestRepository,
-            arguments: arguments
+            httpRequestRepository: self.httpRequestRepository
         )
     }
 
     @MainActor
-    func createVariableForTemplate(data: Any?, properties: [Property]?) -> Variable? {
+    func createVariableForTemplate(data: Any?, properties: [Property]?, arguments: NubrickArguments?) -> Variable? {
         return _createVariableForTemplate(
             user: self.user,
             data: data,
             properties: properties,
             form: self.formRepository.getFormData(),
-            arguments: self.arguments,
+            arguments: arguments,
             projectId: self.config.projectId
         )
     }

--- a/Sources/Nubrick/Data/dependency-container.swift
+++ b/Sources/Nubrick/Data/dependency-container.swift
@@ -34,7 +34,7 @@ struct NubrickDependencyContainer : Sendable {
     }
 
     @MainActor
-    func makeContainer(arguments: NubrickArguments? = nil) -> Container {
+    func makeContainer() -> Container {
         ContainerImpl(
             config: config,
             user: user,
@@ -43,8 +43,7 @@ struct NubrickDependencyContainer : Sendable {
             componentRepository: componentRepository,
             trackRepository: trackRepository,
             databaseRepository: databaseRepository,
-            httpRequestRepository: httpRequestRepository,
-            arguments: arguments
+            httpRequestRepository: httpRequestRepository
         )
     }
 }

--- a/Sources/Nubrick/Data/variable.swift
+++ b/Sources/Nubrick/Data/variable.swift
@@ -5,12 +5,43 @@
 //  Created by Ryosuke Suzuki on 2024/03/07.
 //
 
+import Combine
 import Foundation
 
 // All leaf values are JSON-primitive types (String, Int, Double, Bool, [Any], [String: Any])
 // which are inherently Sendable, but Swift can't prove that through [String: Any].
 struct Variable: @unchecked Sendable {
     let value: [String: Any]
+}
+
+@MainActor
+final class VariableStore: ObservableObject {
+    @Published private(set) var variable: Variable?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(_ variable: Variable? = nil) {
+        self.variable = variable
+    }
+
+    func update(_ variable: Variable?) {
+        self.variable = variable
+    }
+
+    func publisher() -> AnyPublisher<Variable?, Never> {
+        self.$variable.eraseToAnyPublisher()
+    }
+
+    func derived(_ map: @escaping (Variable?) -> Variable?) -> VariableStore {
+        let store = VariableStore(map(self.variable))
+        self.publisher()
+            .dropFirst()
+            .map(map)
+            .sink { [weak store] variable in
+                store?.update(variable)
+            }
+            .store(in: &store.cancellables)
+        return store
+    }
 }
 
 @MainActor
@@ -52,16 +83,11 @@ func _createVariableForTemplate(
 }
 
 func _mergeVariable(base: Variable?, _ overlay: Variable?) -> Variable? {
-    guard let base = base?.value else {
+    guard let baseValue = base?.value else {
         return overlay
     }
-    let overlay = overlay?.value
-    return Variable(value: [
-        "user": overlay?["user"] ?? base["user"] as Any,
-        "props": overlay?["props"] ?? base["props"] as Any,
-        "form": overlay?["form"] ?? base["form"] as Any,
-        "args": overlay?["args"] ?? base["args"] as Any,
-        "data": overlay?["data"] ?? base["data"] as Any,
-        "project": overlay?["project"] ?? base["project"] as Any,
-    ])
+    guard let overlayValue = overlay?.value else {
+        return base
+    }
+    return Variable(value: baseValue.merging(overlayValue) { _, new in new })
 }

--- a/Sources/Nubrick/Data/variable.swift
+++ b/Sources/Nubrick/Data/variable.swift
@@ -33,7 +33,7 @@ final class VariableStore: ObservableObject {
 
     func derived(_ map: @escaping (Variable?) -> Variable?) -> VariableStore {
         let store = VariableStore(map(self.variable))
-        self.publisher()
+        self.$variable
             .dropFirst()
             .map(map)
             .sink { [weak store] variable in
@@ -82,12 +82,8 @@ func _createVariableForTemplate(
     ])
 }
 
-func _mergeVariable(base: Variable?, _ overlay: Variable?) -> Variable? {
-    guard let baseValue = base?.value else {
-        return overlay
-    }
-    guard let overlayValue = overlay?.value else {
-        return base
-    }
-    return Variable(value: baseValue.merging(overlayValue) { _, new in new })
+func _replaceVariableData(base: Variable?, data: Any) -> Variable {
+    var value = base?.value ?? [:]
+    value["data"] = data
+    return Variable(value: value)
 }

--- a/Sources/Nubrick/Util/utils.swift
+++ b/Sources/Nubrick/Util/utils.swift
@@ -21,6 +21,17 @@ func presentOnTop(window: UIWindow?, modal: UIViewController) {
     presented.present(modal, animated: true)
 }
 
+@MainActor
+func invalidateYogaLayout(from view: UIView, layoutRoot: UIView?) {
+    if view.yoga.isEnabled && view.yoga.isLeaf {
+        view.yoga.markDirty()
+    }
+
+    let target = layoutRoot ?? view
+    target.setNeedsLayout()
+    target.invalidateIntrinsicContentSize()
+}
+
 func parseInt(_ data: Int?) -> YGValue {
     if let integer = data {
         return YGValue(value: Float(integer), unit: .point)

--- a/Sources/Nubrick/remote-config.swift
+++ b/Sources/Nubrick/remote-config.swift
@@ -91,7 +91,8 @@ public final class RemoteConfigVariant : Sendable {
         return EmbeddingSwiftView(
             experimentId: self.experimentId,
             componentId: componentId,
-            container: self.container.makeContainer(arguments: arguments),
+            container: self.container,
+            arguments: arguments,
             modalViewController: self.modalViewController,
             onEvent: onEvent
         )
@@ -108,7 +109,8 @@ public final class RemoteConfigVariant : Sendable {
         return EmbeddingSwiftView(
             experimentId: self.experimentId,
             componentId: componentId,
-            container: self.container.makeContainer(arguments: arguments),
+            container: self.container,
+            arguments: arguments,
             modalViewController: self.modalViewController,
             onEvent: onEvent,
             content: content
@@ -127,7 +129,8 @@ public final class RemoteConfigVariant : Sendable {
         let uiview = EmbeddingUIView(
             experimentId: self.experimentId,
             componentId: componentId,
-            container: self.container.makeContainer(arguments: arguments),
+            container: self.container,
+            arguments: arguments,
             modalViewController: self.modalViewController,
             onEvent: onEvent,
             fallback: nil
@@ -148,7 +151,8 @@ public final class RemoteConfigVariant : Sendable {
         let uiview = EmbeddingUIView(
             experimentId: self.experimentId,
             componentId: componentId,
-            container: self.container.makeContainer(arguments: arguments),
+            container: self.container,
+            arguments: arguments,
             modalViewController: self.modalViewController,
             onEvent: onEvent,
             fallback: content

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -263,8 +263,8 @@ final class NubrickCore {
         }
     }
 
-    private func makeContainer(arguments: NubrickArguments? = nil) -> Container {
-        self.dependencies.makeContainer(arguments: arguments)
+    func makeContainer() -> Container {
+        self.dependencies.makeContainer()
     }
 
     func overlayViewController() -> UIViewController {
@@ -283,7 +283,8 @@ final class NubrickCore {
     ) -> some View {
         AnyView(EmbeddingSwiftView(
             experimentId: id,
-            container: self.makeContainer(arguments: arguments),
+            container: self.makeContainer(),
+            arguments: arguments,
             modalViewController: self.overlayVC.modalViewController,
             onEvent: onEvent,
             onSizeChange: onSizeChange
@@ -300,7 +301,8 @@ final class NubrickCore {
         AnyView(EmbeddingSwiftView(
             experimentId: id,
             componentId: nil,
-            container: self.makeContainer(arguments: arguments),
+            container: self.makeContainer(),
+            arguments: arguments,
             modalViewController: self.overlayVC.modalViewController,
             onEvent: onEvent,
             content: content,
@@ -316,7 +318,8 @@ final class NubrickCore {
     ) -> UIView {
         EmbeddingUIView(
             experimentId: id,
-            container: self.makeContainer(arguments: arguments),
+            container: self.makeContainer(),
+            arguments: arguments,
             modalViewController: self.overlayVC.modalViewController,
             onEvent: onEvent,
             fallback: nil,
@@ -333,7 +336,8 @@ final class NubrickCore {
     ) -> UIView {
         EmbeddingUIView(
             experimentId: id,
-            container: self.makeContainer(arguments: arguments),
+            container: self.makeContainer(),
+            arguments: arguments,
             modalViewController: self.overlayVC.modalViewController,
             onEvent: onEvent,
             fallback: content,
@@ -374,7 +378,8 @@ final class NubrickCore {
     ) -> UIView {
         EmbeddingUIView(
             experimentId: id,
-            container: self.makeContainer(arguments: arguments),
+            container: self.makeContainer(),
+            arguments: arguments,
             modalViewController: self.overlayVC.modalViewController,
             onEvent: onEvent,
             fallback: content,
@@ -395,6 +400,7 @@ final class NubrickCore {
             return NubrickBridgedViewAccessor(rootView: RootView(
                 root: decoded,
                 container: self.makeContainer(),
+                arguments: nil,
                 modalViewController: self.overlayVC.modalViewController,
                 onEvent: { event in
                     onEvent?(convertEvent(event))

--- a/Tests/NubrickTests/Component/embedding.swift
+++ b/Tests/NubrickTests/Component/embedding.swift
@@ -6,7 +6,7 @@ let EMBEDDING_ID_1_FOR_TEST = "EMBEDDING_1"
 
 final class EmbeddingUIViewTests: XCTestCase {
     @MainActor
-    private func makeContainer(arguments: NubrickArguments? = nil) throws -> Container {
+    private func makeContainer() throws -> Container {
         let db = try XCTUnwrap(createNativebrikCoreDataHelper(), "Could not init DB")
         let user = NubrickUser()
         let config = Config(projectId: PROJECT_ID_FOR_TEST)
@@ -17,7 +17,7 @@ final class EmbeddingUIViewTests: XCTestCase {
             persistentContainer: db,
             httpRequestInterceptor: nil
         )
-        return dependencies.makeContainer(arguments: arguments)
+        return dependencies.makeContainer()
     }
 
     private func makeComponentRoot(

--- a/Tests/NubrickTests/Data/repository.swift
+++ b/Tests/NubrickTests/Data/repository.swift
@@ -55,7 +55,7 @@ final class HttpRequestReposotiryTests: XCTestCase {
 
 @MainActor
 final class ContainerTests: XCTestCase {
-    private func makeContainer(arguments: NubrickArguments? = nil) throws -> Container {
+    private func makeContainer() throws -> Container {
         let db = try XCTUnwrap(createNativebrikCoreDataHelper(), "Could not init DB")
         let user = NubrickUser()
         let config = Config(projectId: PROJECT_ID_FOR_TEST)
@@ -66,7 +66,7 @@ final class ContainerTests: XCTestCase {
             persistentContainer: db,
             httpRequestInterceptor: nil
         )
-        return dependencies.makeContainer(arguments: arguments)
+        return dependencies.makeContainer()
     }
 
     func testShouldCallApiHttpRequest() async throws {
@@ -82,22 +82,21 @@ final class ContainerTests: XCTestCase {
     }
 
     func testMakeContainerShouldApplyArgumentsPerContext() throws {
-        let root = try makeContainer()
+        let container = try makeContainer()
         let arguments: NubrickArguments = ["bannerId": "banner_123"]
-        let child = root.makeContainer(arguments: arguments)
 
-        let rootVariable = root.createVariableForTemplate(data: nil, properties: nil)
-        let childVariable = child.createVariableForTemplate(data: nil, properties: nil)
+        let noArgsVariable = container.createVariableForTemplate(data: nil, properties: nil, arguments: nil)
+        let withArgsVariable = container.createVariableForTemplate(data: nil, properties: nil, arguments: arguments)
 
-        XCTAssertEqual("", compile("{{ args.bannerId }}", rootVariable))
-        XCTAssertEqual("banner_123", compile("{{ args.bannerId }}", childVariable))
+        XCTAssertEqual("", compile("{{ args.bannerId }}", noArgsVariable))
+        XCTAssertEqual("banner_123", compile("{{ args.bannerId }}", withArgsVariable))
     }
 
     func testMakeContainerShouldIsolateFormState() throws {
         let root = try makeContainer()
         root.setFormValue(key: "email", value: "root@example.com")
 
-        let child = root.makeContainer(arguments: nil)
+        let child = root.makeContainer()
         let rootEmailBefore = root.getFormValue(key: "email") as? String
         let childEmailBefore = child.getFormValue(key: "email") as? String
         XCTAssertEqual("root@example.com", rootEmailBefore)


### PR DESCRIPTION
## Summary
- Make rendered text and image values update reactively from variable changes.
- Avoid creating reactive subscriptions for static text, image, and background image values.
- Skip no-op argument updates when both previous and new arguments are nil.

## Validation
- Built with `xcodebuild -project Nubrick/Nubrick.xcodeproj -scheme Nubrick -destination 'generic/platform=iOS Simulator' build`.

## Notes
- Follow-up reactive work such as form repository behavior and HTTP refetch behavior to be done in future PR