### PR TITLE
Make user data trigger update using Combine

### DIFF
--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -147,6 +147,13 @@ final class PageView: UIView {
             }
             .store(in: &self.cancellables)
 
+        container.userDataPublisher()
+            .dropFirst()
+            .sink { [weak self] userData in
+                self?.variableStore.updateUser(userData)
+            }
+            .store(in: &self.cancellables)
+
         self.actionHandler = { [weak self] action, onHttpSettled in
             guard let self else {
                 return

--- a/Sources/Nubrick/Data/container.swift
+++ b/Sources/Nubrick/Data/container.swift
@@ -29,6 +29,8 @@ protocol Container : Sendable {
     func setFormValue(key: String, value: Any)
     @MainActor
     func formDataPublisher() -> AnyPublisher<[String: Any], Never>
+    @MainActor
+    func userDataPublisher() -> AnyPublisher<[String: Any], Never>
 
     func sendHttpRequest(req: ApiHttpRequest, assertion: ApiHttpResponseAssertion?, variable: Variable?) async -> Result<JSONData, NubrickError>
     func fetchEmbedding(experimentId: String, componentId: String?) async -> Result<UIBlock, NubrickError>
@@ -118,6 +120,11 @@ final class ContainerImpl: Container {
     @MainActor
     func formDataPublisher() -> AnyPublisher<[String: Any], Never> {
         self.formRepository.formDataPublisher
+    }
+
+    @MainActor
+    func userDataPublisher() -> AnyPublisher<[String: Any], Never> {
+        self.user.userDataPublisher
     }
 
     // MARK: - HTTP Request

--- a/Sources/Nubrick/Data/user.swift
+++ b/Sources/Nubrick/Data/user.swift
@@ -5,6 +5,7 @@
 //  Created by Ryosuke Suzuki on 2023/08/28.
 //
 
+import Combine
 import Foundation
 import UIKit
 
@@ -64,8 +65,8 @@ private func formatUserPropertyValue(_ value: Any) -> String {
 
 @MainActor
 class NubrickUser {
-    private var properties: [String: String]
-    private var customProperties: [String: String]
+    @Published private var properties: [String: String]
+    @Published private var customProperties: [String: String]
     private var lastBootTime: Double = getCurrentDate().timeIntervalSince1970
     internal var userDB: UserDefaults
 
@@ -116,6 +117,17 @@ class NubrickUser {
         }
 
         self.comeBack()
+    }
+
+    var userDataPublisher: AnyPublisher<[String: Any], Never> {
+        Publishers.CombineLatest($properties, $customProperties)
+            .map { props, custom -> [String: Any] in
+                let userId = props[BuiltinUserProperty.userId.rawValue] ?? ""
+                var userData: [String: Any] = ["id": userId, BuiltinUserProperty.userId.rawValue: userId]
+                custom.forEach { userData[$0.key] = $0.value }
+                return userData
+            }
+            .eraseToAnyPublisher()
     }
 
     var id: String {

--- a/Sources/Nubrick/Data/variable.swift
+++ b/Sources/Nubrick/Data/variable.swift
@@ -33,6 +33,12 @@ final class VariableStore {
         self.variable = Variable(value: value)
     }
 
+    func updateUser(_ userData: [String: Any]) {
+        guard var value = self.variable?.value else { return }
+        value["user"] = userData.isEmpty ? nil : userData as Any
+        self.variable = Variable(value: value)
+    }
+
     func publisher() -> AnyPublisher<Variable?, Never> {
         self.$variable.eraseToAnyPublisher()
     }


### PR DESCRIPTION
## Summary
- Added `@Published` to `properties` and `customProperties` in `NubrickUser` to enable reactive observation
- Exposed a `userDataPublisher` on `NubrickUser` and wired it through the `Container` protocol
- `PageView` now subscribes to user data changes and calls `VariableStore.updateUser(_:)` to keep variables in sync, mirroring the existing form data reactive pattern