### PR TITLE
Make page loading state and HTTP requests reactive via Combine

### DIFF
--- a/Example-Local/Example-Local/Configuration/Debug.xcconfig
+++ b/Example-Local/Example-Local/Configuration/Debug.xcconfig
@@ -1,4 +1,4 @@
-PROJECT_ID = cgv3p3223akg00fod19g
+PROJECT_ID = p_d357ola9io6g00f6evag
 INFOPLIST_FILE = $(SRCROOT)/Example-Local/Info.plist
 GENERATE_INFOPLIST_FILE = NO
 

--- a/Example-Local/Example-Local/ContentView.swift
+++ b/Example-Local/Example-Local/ContentView.swift
@@ -1,176 +1,64 @@
 import SwiftUI
 import Nubrick
 
-struct ItemBuyButton: View {
-    let price: String
-    let onAction: () -> ()
-    var body: some View {
-        VStack {
-            Divider()
-            HStack {
-                Text(self.price).fontWeight(.medium)
-                Spacer()
-                Button(action: {
-                    self.onAction()
-                }) {
-                    Text("Book").foregroundColor(.white).fontWeight(.medium)
-                }.padding(.horizontal, 38).padding(.vertical, 8).background(.primary).cornerRadius(8)
-            }.padding(.horizontal, 16).padding(.vertical, 8)
-        }
-    }
-}
+private enum SampleUserPlan {
+    static var value = "pro"
 
-struct ItemPanel: View {
-    let image: String
-    let title: String
-    let subtitle: String
-    let price: String
-    var desc: String = "Lorem Ipsum"
-
-    @State private var isShowingItemView = false
-
-    var body: some View {
-        VStack {
-            AsyncImage(url: URL(string: self.image)) { phase in
-                if let image = phase.image {
-                    image.resizable().scaledToFill()
-                } else {
-                    ProgressView()
-                }
-            }.frame(width: UIScreen.main.bounds.size.width - 32, height: 200).cornerRadius(8).clipped()
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    VStack(alignment: .leading, spacing: 0) {
-                        Text(self.title).fontWeight(.medium).font(.caption)
-                        Text(self.subtitle).foregroundColor(.secondary).font(.caption)
-                    }
-                    Text(self.price).fontWeight(.medium).font(.caption)
-                }
-                Spacer()
-            }
-        }.onTapGesture {
-            self.isShowingItemView.toggle()
-        }.sheet(isPresented: self.$isShowingItemView) {
-            VStack(alignment: .leading, spacing: 8) {
-                ScrollView(.vertical) {
-                    AsyncImage(url: URL(string: self.image)) { phase in
-                        if let image = phase.image {
-                            image.resizable().scaledToFill()
-                        } else {
-                            ProgressView()
-                        }
-                    }.frame(width: UIScreen.main.bounds.size.width, height: 280)
-                    HStack {
-                        VStack(alignment: .leading, spacing: 4) {
-                            VStack(alignment: .leading, spacing: 0) {
-                                Text(self.title).fontWeight(.medium).font(.title)
-                                Text(self.subtitle).foregroundColor(.secondary).font(.subheadline)
-                                Text(self.desc).fontWeight(.light).padding(.top, 16)
-                            }
-                        }
-                        Spacer()
-                    }.padding()
-                }
-                ItemBuyButton(
-                    price: self.price,
-                    onAction: {
-                        self.isShowingItemView.toggle()
-                    }
-                )
-            }
-        }
-    }
-}
-
-struct SearchBar: View {
-    var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "magnifyingglass").padding(.leading, 8)
-            VStack(alignment: .leading) {
-                Text("Where you want to visit?").font(.caption)
-                Text("Any area").foregroundColor(.secondary).font(.caption)
-            }
-            Spacer()
-        }.padding(8).background(.background).cornerRadius(8).shadow(color: .init(.sRGBLinear, white: 0, opacity: 0.08), radius: 4)
-    }
-}
-
-struct Header: View {
-    var body: some View {
-        SearchBar().padding().background(.background)
-    }
-}
-
-struct AppView: View {
-    let items: [ItemPanel] = [
-        ItemPanel(image: "https://www.cairnsdiscoverytours.com/wp-content/uploads/2022/10/cairns-city-day-tours.jpg", title: "Cairns, Australia", subtitle: "A city in Queensland", price: "$800 round trip", desc: "Cairns is a vibrant and tropical city located in the far north of Queensland, Australia. Situated on the east coast, Cairns serves as the gateway to the Great Barrier Reef, one of the world's most renowned natural wonders. The city's stunning location between lush rainforests and the Coral Sea makes it a popular tourist destination."),
-        ItemPanel(image: "https://lifeofdoing.com/wp-content/uploads/2020/05/5-Days-In-Kyoto-Itinerary-Higashiyama-District.jpg", title: "Kyoto, Japan", subtitle: "A city in Japan", price: "$300 round trip", desc: """
-Kyoto, located in the Kansai region of Japan, is a city steeped in history, tradition, and natural beauty. As the former imperial capital of Japan for over a thousand years, Kyoto is renowned for its well-preserved historic sites, traditional culture, and stunning temples and gardens.
-"""),
-        ItemPanel(image: "https://dynamic-media-cdn.tripadvisor.com/media/photo-o/1b/6c/16/ce/caption.jpg?w=1200&h=-1&s=1", title: "Sao paulo, Brazil", subtitle: "A city in Brazil", price: "$1800 round trip", desc: """
-São Paulo, often referred to as Sampa, is a bustling metropolis and the largest city in Brazil. Located in the southeastern part of the country, São Paulo is a dynamic hub of culture, business, and diversity. It is known for its vibrant energy, impressive skyline, and a wide range of attractions that cater to various interests.
-"""),
-        ItemPanel(image: "https://griffithobservatory.org/wp-content/uploads/2021/03/cameron-venti-c5GkEd-j5vI-unsplash_noCautionTape-1600x800-1638571089.jpg", title: "Los angeles, America", subtitle: "A city in California", price: "$900 round trip", desc: """
-Los Angeles, often referred to as LA, is a vibrant and diverse city located on the west coast of the United States in Southern California. As the second-largest city in the country and the entertainment capital of the world, Los Angeles offers a unique blend of glamour, cultural richness, natural beauty, and a laid-back coastal lifestyle.
-"""),
-        ItemPanel(image: "https://www.nationsonline.org/gallery/Madagascar/Allee-des-Baobabs-Madagascar.jpg", title: "Morondava, Madagascar", subtitle: "A city in Madagascar", price: "$1400 round trip", desc: """
-Morondava is a charming coastal town located on the western coast of Madagascar. Situated in the Menabe region, Morondava is known for its breathtaking natural beauty, unique baobab trees, and laid-back atmosphere. It offers visitors a chance to experience the rich culture, stunning landscapes, and warm hospitality of Madagascar.
-""")
-    ]
-    
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            NubrickSDK.embedding("HEADER_INFORMATION") { phase in
-                    switch phase {
-                    case .completed(let view):
-                        view.frame(height: 60)
-                    default:
-                        EmptyView().frame(height: 0)
-                    }
-                }
-            Header()
-            ScrollView(.vertical) {
-                NubrickSDK.embedding("TOP_COMPONENT") { phase in
-                        switch phase {
-                        case .completed(let view):
-                            view.frame(width: nil, height: 280)
-                        default:
-                            EmptyView().frame(width: nil, height: 0)
-                        }
-                    }
-                ForEach(self.items, id: \.title) { item in
-                    item.padding()
-                }
-            }
-        }
+    static func toggle() -> String {
+        value = value == "pro" ? "free" : "pro"
+        return value
     }
 }
 
 struct ContentView: View {
-    var body: some View {
-        AppView()
-    }
-}
+    @State private var counter = 0
+    @State private var plan = "pro"
 
-@MainActor
-private struct NubrickPreviewRoot: View {
-    private static var didInit = false
-
-    init() {
-        if !Self.didInit {
-            NubrickSDK.initialize(projectId: "cgv3p3223akg00fod19g")
-            Self.didInit = true
-        }
+    var arguments: [String: any Sendable] {
+        ["counter": counter]
     }
 
     var body: some View {
-        NubrickProvider {
-            ContentView()
+        ScrollView(.vertical) {
+            VStack {
+                NubrickSDK.embedding("HEADER_INFORMATION", arguments: arguments) { phase in
+                    switch phase {
+                    case .completed(let view):
+                        view.frame(height: 100)
+                    default:
+                        EmptyView().frame(height: 0)
+                    }
+                }
+                NubrickSDK.embedding("TOP_COMPONENT", arguments: arguments) { phase in
+                    switch phase {
+                    case .completed(let view):
+                        view.frame(height: 270)
+                    default:
+                        EmptyView().frame(height: 0)
+                    }
+                }
+                Spacer().frame(height: 16)
+                VStack(spacing: 8) {
+                    HStack {
+                        Button("arg counter: \(counter)") {
+                            counter += 1
+                        }
+                        Spacer().frame(width: 8)
+                        Button("user plan + state: \(plan)") {
+                            plan = plan == "pro" ? "free" : "pro"
+                            NubrickSDK.setUserProperty("plan", value: plan)
+                        }
+                    }
+                    Button("user plan SDK only") {
+                        let plan = SampleUserPlan.toggle()
+                        NubrickSDK.setUserProperty("plan", value: plan)
+                    }
+                }.padding(.horizontal)
+            }
         }
     }
 }
 
 #Preview {
-    NubrickPreviewRoot()
+    ContentView()
 }

--- a/Example-Local/Example-Local/Example_LocalApp.swift
+++ b/Example-Local/Example-Local/Example_LocalApp.swift
@@ -24,6 +24,12 @@ struct ExampleApp: App {
         NubrickSDK.initialize(
             projectId: projectId
         )
+        NubrickSDK.setUserId("user-42")
+        NubrickSDK.setUserProperties([
+            "name": "Victor",
+            "plan": "pro",
+            "locale": "en",
+        ])
     }
 
     var body: some Scene {

--- a/Sources/Nubrick/Component/context.swift
+++ b/Sources/Nubrick/Component/context.swift
@@ -19,7 +19,6 @@ struct UIBlockContextInit {
     var parentClickListener: ClickListener? = nil
     var parentDirection: FlexDirection? = nil
     var layoutInvalidationRoot: UIView? = nil
-    var loading: Bool? = false
 }
 
 struct UIBlockContextChildInit {
@@ -30,7 +29,6 @@ struct UIBlockContextChildInit {
     var parentClickListener: ClickListener? = nil
     var parentDirection: FlexDirection? = nil
     var layoutInvalidationRoot: UIView? = nil
-    var loading: Bool? = false
 }
 
 @MainActor
@@ -43,7 +41,6 @@ class UIBlockContext {
     private var parentClickListener: ClickListener?
     private var parentDirection: FlexDirection?
     private weak var layoutInvalidationRoot: UIView?
-    private var loading: Bool = false
 
     init(_ args: UIBlockContextInit) {
         self.variableStore = args.variableStore ?? VariableStore()
@@ -52,7 +49,6 @@ class UIBlockContext {
         self.parentClickListener = args.parentClickListener
         self.parentDirection = args.parentDirection
         self.layoutInvalidationRoot = args.layoutInvalidationRoot
-        self.loading = args.loading ?? false
         self.container = args.container
     }
 
@@ -74,8 +70,7 @@ class UIBlockContext {
                 actionHandler: args.actionHandler ?? self.actionHandler,
                 parentClickListener: args.parentClickListener ?? self.parentClickListener,
                 parentDirection: args.parentDirection ?? self.parentDirection,
-                layoutInvalidationRoot: args.layoutInvalidationRoot ?? self.layoutInvalidationRoot,
-                loading: args.loading ?? self.loading
+                layoutInvalidationRoot: args.layoutInvalidationRoot ?? self.layoutInvalidationRoot
             ))
     }
 
@@ -91,8 +86,8 @@ class UIBlockContext {
         return self.layoutInvalidationRoot
     }
 
-    func isLoading() -> Bool {
-        return self.loading
+    func loadingPublisher() -> AnyPublisher<Bool, Never> {
+        return self.variableStore.loadingPublisher()
     }
 
     func hasParent() -> Bool {

--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -10,6 +10,18 @@ import Foundation
 import UIKit
 internal import YogaKit
 
+private struct CompiledPageRequest: Equatable {
+    struct Header: Equatable { let name: String; let value: String }
+    let url: String
+    let body: String
+    let headers: [Header]
+}
+
+private struct PageHttpRequestSnapshot {
+    let compiledRequest: CompiledPageRequest
+    let variable: Variable?
+}
+
 // child of modal
 class ModalPageViewController: UIViewController {
     private var isFirstModal = false
@@ -106,11 +118,12 @@ final class PageView: UIView {
     private var responseData: Any? = nil
     private var actionHandler: UIBlockActionHandler? = nil
     private var fullScreenInitialNavItemVisibility = false
-    private var loading: Bool = false
     private var view: UIView = UIView()
 
     private var modalViewController: ModalComponentViewController? = nil
     private var cancellables = Set<AnyCancellable>()
+    private var pageHttpRequestTask: Task<Void, Never>?
+    private var pageHttpRequestSequence = 0
 
     @available(*, unavailable, message: "Storyboard/XIB initialization is not supported. Use init(page:props:container:arguments:actionHandler:modalViewController:).")
     required init?(coder: NSCoder) {
@@ -137,7 +150,7 @@ final class PageView: UIView {
             data: nil,
             properties: self.props,
             arguments: arguments
-        ))
+        ), loading: page?.data?.httpRequest != nil)
         super.init(frame: .zero)
 
         container.formDataPublisher()
@@ -210,6 +223,10 @@ final class PageView: UIView {
         self.loadDataAndTransition()
     }
 
+    deinit {
+        self.pageHttpRequestTask?.cancel()
+    }
+
     func dispatchAction(_ action: UIBlockAction) {
         self.actionHandler?(action, nil)
     }
@@ -233,41 +250,63 @@ final class PageView: UIView {
 
     func loadDataAndTransition() {
         guard let httpRequest = self.page?.data?.httpRequest else {
-            self.loading = false
             self.renderView()
             return
         }
 
-        // when it has http request, render loading view, and then
-        self.loading = true
         self.renderView()
 
-        Task {
-            let variable = self.container.createVariableForTemplate(
-                data: nil,
-                properties: self.props,
-                arguments: self.arguments
-            )
-            let result = await self.container.sendHttpRequest(
-                req: httpRequest,
-                assertion: nil,
-                variable: variable
-            )
-            await MainActor.run { [weak self] in
-                guard let self else {
-                    return
-                }
-                switch result {
-                case .success(let response):
-                    self.responseData = response.data?.value
-                    self.variableStore.update(self.createVariable())
-                default:
-                    break
-                }
-                self.loading = false
-                self.renderView()
+        variableStore.publisher()
+            .map { [weak self] variable -> PageHttpRequestSnapshot in
+                let compiledRequest = CompiledPageRequest(
+                    url: compile(httpRequest.url ?? "", variable),
+                    body: compile(httpRequest.body ?? "", variable),
+                    headers: (httpRequest.headers ?? []).map {
+                        .init(name: compile($0.name ?? "", variable),
+                              value: compile($0.value ?? "", variable))
+                    }
+                )
+                return PageHttpRequestSnapshot(compiledRequest: compiledRequest, variable: variable)
             }
-        }
+            .removeDuplicates { previous, current in
+                previous.compiledRequest == current.compiledRequest
+            }
+            .sink { [weak self] snapshot in
+                guard let self else { return }
+                let variable = snapshot.variable
+                self.pageHttpRequestSequence += 1
+                let requestSequence = self.pageHttpRequestSequence
+                self.pageHttpRequestTask?.cancel()
+                self.variableStore.updateLoading(true)
+                let container = self.container
+                self.pageHttpRequestTask = Task { [weak self, container] in
+                    let result = await container.sendHttpRequest(
+                        req: httpRequest,
+                        assertion: nil,
+                        variable: variable
+                    )
+                    await MainActor.run { [weak self] in
+                        guard let self else { return }
+                        guard self.pageHttpRequestSequence == requestSequence else {
+                            return
+                        }
+                        defer {
+                            if self.pageHttpRequestSequence == requestSequence {
+                                self.variableStore.updateLoading(false)
+                                self.pageHttpRequestTask = nil
+                            }
+                        }
+                        guard !Task.isCancelled else {
+                            return
+                        }
+                        if case .success(let response) = result {
+                            self.responseData = response.data?.value
+                            self.variableStore.updateData(response.data?.value)
+                        }
+                    }
+                }
+            }
+            .store(in: &cancellables)
     }
 
     func renderView() {
@@ -280,8 +319,7 @@ final class PageView: UIView {
                         container: self.container,
                         variableStore: self.variableStore,
                         actionHandler: self.actionHandler,
-                        layoutInvalidationRoot: self,
-                        loading: self.loading
+                        layoutInvalidationRoot: self
                     )
                 ),
                 respectSafeArea: self.page?.data?.modalRespectSafeArea

--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -257,7 +257,7 @@ final class PageView: UIView {
         self.renderView()
 
         variableStore.publisher()
-            .map { [weak self] variable -> PageHttpRequestSnapshot in
+            .map { variable -> PageHttpRequestSnapshot in
                 let compiledRequest = CompiledPageRequest(
                     url: compile(httpRequest.url ?? "", variable),
                     body: compile(httpRequest.body ?? "", variable),

--- a/Sources/Nubrick/Component/renderer/image.swift
+++ b/Sources/Nubrick/Component/renderer/image.swift
@@ -26,15 +26,11 @@ class ImageView: AnimatedUIControl {
         self.block = block
         self.context = context
 
-        let showSkelton = context.isLoading() && hasPlaceholderPath(template: block.data?.src ?? "")
-
         self.configureLayout { layout in
             layout.isEnabled = true
 
             configurePadding(layout: layout, frame: block.data?.frame)
             configureSize(layout: layout, frame: block.data?.frame, parentDirection: context.getParentDireciton())
-
-            configureSkelton(view: self, showSkelton: showSkelton)
         }
 
         self.image.configureLayout { layout in
@@ -81,6 +77,19 @@ class ImageView: AnimatedUIControl {
         }
 
         let srcTemplate = self.block.data?.src ?? ""
+        let showSkeltonOnLoading = hasDataPlaceholderPath(template: srcTemplate)
+
+        context.loadingPublisher()
+            .sink { [weak self] loading in
+                guard let self else { return }
+                if loading && showSkeltonOnLoading {
+                    configureSkelton(view: self)
+                } else {
+                    removeSkelton(view: self, frame: self.block.data?.frame)
+                }
+            }
+            .store(in: &self.cancellables)
+
         guard hasPlaceholderPath(template: srcTemplate) else {
             self.applyImageSource(srcTemplate)
             return

--- a/Sources/Nubrick/Component/renderer/text.swift
+++ b/Sources/Nubrick/Component/renderer/text.swift
@@ -15,18 +15,14 @@ class TextView: AnimatedUIControl, BackgroundImageObserver {
     
     init(block: UITextBlock, context: UIBlockContext) {
         super.init(frame: .zero)
-        let showSkelton = context.isLoading() && hasPlaceholderPath(template: block.data?.value ?? "")
-
         self.block = block
         self.context = context
         self.configureLayout { layout in
             layout.isEnabled = true
             layout.display = .flex
             layout.direction = .LTR
-            
-            configureSkelton(view: self, showSkelton: showSkelton)
         }
-        
+
         let label = UILabel()
         label.yoga.isEnabled = true
         if let color = block.data?.color {
@@ -40,7 +36,6 @@ class TextView: AnimatedUIControl, BackgroundImageObserver {
         } else {
             label.numberOfLines = 0
         }
-        configureSkeltonText(view: label, showSkelton: showSkelton)
         
         self.label = label
         self.addSubview(label)
@@ -71,17 +66,40 @@ class TextView: AnimatedUIControl, BackgroundImageObserver {
         }
 
         let textTemplate = self.block.data?.value ?? ""
+        let showSkeltonOnLoading = hasDataPlaceholderPath(template: textTemplate)
+
         if hasPlaceholderPath(template: textTemplate) {
             var shouldInvalidateLayout = false
-            context.variablePublisher()
+            var previousText: String?
+            let textPublisher = context.variablePublisher()
                 .map { compile(textTemplate, $0) }
                 .removeDuplicates()
-                .sink { [weak self] text in
+
+            context.loadingPublisher()
+                .combineLatest(textPublisher)
+                .removeDuplicates { previous, current in
+                    previous.0 == current.0 && previous.1 == current.1
+                }
+                .sink { [weak self] loading, text in
                     guard let self else { return }
+                    if loading && showSkeltonOnLoading {
+                        configureSkelton(view: self)
+                        configureSkeltonText(view: self.label)
+                        shouldInvalidateLayout = true
+                        return
+                    }
+
+                    removeSkelton(view: self, frame: self.block.data?.frame)
                     self.label.text = text
-                    if shouldInvalidateLayout {
+                    if let color = self.block.data?.color {
+                        self.label.textColor = parseColor(color)
+                    } else {
+                        self.label.textColor = .label
+                    }
+                    if shouldInvalidateLayout && previousText != text {
                         invalidateYogaLayout(from: self.label, layoutRoot: context.getLayoutInvalidationRoot())
                     }
+                    previousText = text
                     shouldInvalidateLayout = true
                 }
                 .store(in: &self.cancellables)

--- a/Sources/Nubrick/Data/variable.swift
+++ b/Sources/Nubrick/Data/variable.swift
@@ -17,14 +17,26 @@ struct Variable: @unchecked Sendable {
 @MainActor
 final class VariableStore {
     @Published private(set) var variable: Variable?
+    @Published private(set) var loading: Bool = false
     private var cancellables = Set<AnyCancellable>()
 
-    init(_ variable: Variable? = nil) {
+    init(_ variable: Variable? = nil, loading: Bool = false) {
         self.variable = variable
+        self.loading = loading
     }
 
     func update(_ variable: Variable?) {
         self.variable = variable
+    }
+
+    func updateLoading(_ loading: Bool) {
+        self.loading = loading
+    }
+
+    func updateData(_ data: Any?) {
+        guard var value = self.variable?.value else { return }
+        value["data"] = data as Any
+        self.variable = Variable(value: value)
     }
 
     func updateForm(_ form: [String: Any]) {
@@ -43,13 +55,23 @@ final class VariableStore {
         self.$variable.eraseToAnyPublisher()
     }
 
+    func loadingPublisher() -> AnyPublisher<Bool, Never> {
+        self.$loading.eraseToAnyPublisher()
+    }
+
     func derived(_ map: @escaping (Variable?) -> Variable?) -> VariableStore {
-        let store = VariableStore(map(self.variable))
+        let store = VariableStore(map(self.variable), loading: self.loading)
         self.$variable
             .dropFirst()
             .map(map)
             .sink { [weak store] variable in
                 store?.update(variable)
+            }
+            .store(in: &store.cancellables)
+        self.$loading
+            .dropFirst()
+            .sink { [weak store] loading in
+                store?.updateLoading(loading)
             }
             .store(in: &store.cancellables)
         return store

--- a/Sources/Nubrick/Interpolation/compiler.swift
+++ b/Sources/Nubrick/Interpolation/compiler.swift
@@ -50,6 +50,21 @@ func hasPlaceholderPath(template: String) -> Bool {
     return regex.numberOfMatches(in: template, range: NSRange(location: 0, length: templateAsNsstring.length)) > 0
 }
 
+func hasDataPlaceholderPath(template: String) -> Bool {
+    guard let regex = placeholderRegex else {
+        return false
+    }
+    let templateAsNsstring = template as NSString
+    let matches = regex.matches(in: template, range: NSRange(location: 0, length: templateAsNsstring.length))
+    return matches.contains { match in
+        let rawPlaceholder = templateAsNsstring.substring(with: match.range)
+        guard let placeholder = getPlaceholder(placeholder: rawPlaceholder) else {
+            return false
+        }
+        return placeholder.path == "data" || placeholder.path.hasPrefix("data.")
+    }
+}
+
 func compile(_ template: String, _ variable: Variable?) -> String {
     guard let regex = placeholderRegex else {
         return template

--- a/Sources/Nubrick/Util/utils.swift
+++ b/Sources/Nubrick/Util/utils.swift
@@ -513,10 +513,7 @@ func configureShadow(view: UIView, shadow: BoxShadow?) {
 }
 
 @MainActor
-func configureSkelton(view: UIView, showSkelton: Bool) {
-    if showSkelton == false {
-        return
-    }
+func configureSkelton(view: UIView) {
     let gray = 0.5
     let alpha = 0.3
     view.layer.backgroundColor = .init(gray: gray, alpha: alpha)
@@ -537,16 +534,23 @@ func configureSkelton(view: UIView, showSkelton: Bool) {
 }
 
 @MainActor
-func configureSkeltonText(view: UILabel, showSkelton: Bool) {
-    if showSkelton == false {
-        return
-    }
+func configureSkeltonText(view: UILabel) {
     let text = view.text ?? ""
     if text.lengthOfBytes(using: .utf8) < 2 {
         view.text = "TRANSPARENT"
     }
 
     view.textColor = .init(white: 0, alpha: 0)
+}
+
+@MainActor
+func removeSkelton(view: UIView, frame: FrameData?) {
+    view.layer.removeAllAnimations()
+    if let background = frame?.background {
+        view.layer.backgroundColor = parseColorToCGColor(background)
+    } else {
+        view.layer.backgroundColor = nil
+    }
 }
 
 func clamp<V: Comparable>(_ value: V, min minValue: V, max maxValue: V) -> V {


### PR DESCRIPTION
## Summary

- Move loading state into `VariableStore` as a `@Published` property, exposing `loadingPublisher()` so renderers can subscribe reactively instead of reading a static flag at init time
- Rewrite page HTTP request firing as a Combine pipeline that re-executes whenever compiled URL/body/headers change, cancels in-flight requests on variable change, and handles race conditions via a sequence counter
- Update `ImageView` and `TextView` skeleton display to subscribe to `loadingPublisher()` and show/remove skeletons dynamically; add `removeSkelton` utility and `hasDataPlaceholderPath` helper to target only `data`-path templates
- Propagate loading state through `VariableStore.derived()` so child stores stay in sync