### PR TITLE
Add Sendable conformance to UIBlock

### DIFF
--- a/Sources/Nubrick/Schema/generated.swift
+++ b/Sources/Nubrick/Schema/generated.swift
@@ -391,7 +391,7 @@ struct TriggerSetting: Decodable, Encodable {
   var onTrigger: UIBlockAction?
   var trigger: TriggerEventDef?
 }
-indirect enum UIBlock: Decodable, Encodable {
+indirect enum UIBlock: Decodable, Encodable, Sendable {
   case EUIRootBlock(UIRootBlock)
   case EUIPageBlock(UIPageBlock)
   case EUIFlexContainerBlock(UIFlexContainerBlock)


### PR DESCRIPTION
## Summary

- Adds `Sendable` conformance to the `indirect enum UIBlock` in the generated schema, enabling safe use across Swift concurrency contexts.