### PR TITLE
Refactor action-listener: replace AnimatedUIControl and ClickListener

### DIFF
--- a/Sources/Nubrick/Component/action-listener.swift
+++ b/Sources/Nubrick/Component/action-listener.swift
@@ -52,7 +52,6 @@ class AnimatedUIView: UIView {
 
         if uiBlockAction != nil {
             let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
-            tap.cancelsTouchesInView = false
             addGestureRecognizer(tap)
         }
 

--- a/Sources/Nubrick/Component/action-listener.swift
+++ b/Sources/Nubrick/Component/action-listener.swift
@@ -9,126 +9,81 @@ import Combine
 import Foundation
 import UIKit
 
-class AnimatedUIControl: UIControl {
-    fileprivate var defaultOpacity: Float? = nil
-    fileprivate var clickListener: ClickListener? = nil
-    func setClickListener(clickListener: ClickListener) {
-        self.clickListener = clickListener
-    }
+class AnimatedUIView: UIView {
+    private var onClick: (() -> Void)?
+    private var onTouchBegan: (() -> Void)?
+    private var onTouchEnded: (() -> Void)?
+    private var onTouchCanceled: (() -> Void)?
+
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
-        if let process = self.clickListener?.onTouchBegan {
-            process()
-        }
+        onTouchBegan?()
     }
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesEnded(touches, with: event)
-        if let process = self.clickListener?.onTouchEnded {
-            process()
-        }
+        onTouchEnded?()
     }
     override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesCancelled(touches, with: event)
-        if let process = self.clickListener?.onTouchCanceled {
-            process()
-        }
+        onTouchCanceled?()
     }
-    @objc func onClicked(sender: ClickListener) {
-        if sender.state == .ended {
-            if let onClick = sender.onClick {
-                onClick()
+
+    @objc private func handleTap() {
+        onClick?()
+    }
+
+    @MainActor
+    func configureOnClickGesture(context: UIBlockContext, uiBlockAction: UIBlockAction?) {
+        onClick = { [weak self] in
+            guard let uiBlockAction = uiBlockAction else { return }
+            let compiledAction = compileAction(action: uiBlockAction, context: context)
+            if uiBlockAction.httpRequest != nil {
+                self?.isUserInteractionEnabled = false
+                self?.alpha = 0.8
+            }
+            context.dispatch(
+                action: compiledAction,
+                onHttpSettled: { [weak self] in
+                    self?.isUserInteractionEnabled = true
+                    self?.alpha = 1
+                }
+            )
+        }
+
+        if uiBlockAction != nil {
+            let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+            tap.cancelsTouchesInView = false
+            addGestureRecognizer(tap)
+        }
+
+        onTouchBegan = { [weak self] in
+            if uiBlockAction != nil && context.hasParent() {
+                UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut) {
+                    self?.transform = CGAffineTransform(scaleX: 0.984, y: 0.984)
+                }
+            } else {
+                context.getParentView()?.onTouchBegan?()
+            }
+        }
+        onTouchEnded = { [weak self] in
+            if uiBlockAction != nil && context.hasParent() {
+                UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut) {
+                    self?.transform = CGAffineTransform(scaleX: 1, y: 1)
+                }
+            } else {
+                context.getParentView()?.onTouchEnded?()
+            }
+        }
+        onTouchCanceled = { [weak self] in
+            if uiBlockAction != nil && context.hasParent() {
+                UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut) {
+                    self?.transform = CGAffineTransform(scaleX: 1, y: 1)
+                }
+            } else {
+                context.getParentView()?.onTouchCanceled?()
             }
         }
     }
-}
-
-class ClickListener: UITapGestureRecognizer {
-    var onClick: (() -> Void)? = nil
-    var onTouchBegan: (() -> Void)? = nil
-    var onTouchEnded: (() -> Void)? = nil
-    var onTouchCanceled: (() -> Void)? = nil
-}
-
-// configureOnClickGesture sets up a click listener for the target view.
-@MainActor
-func configureOnClickGesture(
-    target: UIView, selector: Selector, context: UIBlockContext, uiBlockAction: UIBlockAction?
-) -> ClickListener {
-    let gesture = ClickListener(target: target, action: selector)
-    gesture.onClick = { [weak target] in
-        guard let uiBlockAction = uiBlockAction else { return }
-        let compiledAction = compileAction(action: uiBlockAction, context: context)
-        if uiBlockAction.httpRequest != nil {
-            // set loading UI
-            target?.isUserInteractionEnabled = false
-            target?.alpha = 0.8
-        }
-        context.dispatch(
-            action: compiledAction,
-            onHttpSettled: { [weak target] in
-                // reset loading UI
-                target?.isUserInteractionEnabled = true
-                target?.alpha = 1
-            }
-        )
-    }
-    if uiBlockAction != nil {
-        target.addGestureRecognizer(gesture)
-    }
-
-    gesture.onTouchBegan = {
-        if uiBlockAction != nil && context.hasParent() {
-            UIView.animate(
-                withDuration: 0.1,
-                delay: 0,
-                options: .curveEaseInOut,
-                animations: { [weak target] in
-                    target?.transform = CGAffineTransform(scaleX: 0.984, y: 0.984)
-                })
-        } else {
-            if let onTouchBegan = context.getParentClickListener()?.onTouchBegan {
-                onTouchBegan()
-            }
-        }
-    }
-    gesture.onTouchEnded = {
-        if uiBlockAction != nil && context.hasParent() {
-            UIView.animate(
-                withDuration: 0.1,
-                delay: 0,
-                options: .curveEaseInOut,
-                animations: { [weak target] in
-                    target?.transform = CGAffineTransform(scaleX: 1, y: 1)
-                })
-        } else {
-            if let onTouchBegan = context.getParentClickListener()?.onTouchEnded {
-                onTouchBegan()
-            }
-        }
-
-    }
-    gesture.onTouchCanceled = {
-        if uiBlockAction != nil && context.hasParent() {
-            UIView.animate(
-                withDuration: 0.1,
-                delay: 0,
-                options: .curveEaseInOut,
-                animations: { [weak target] in
-                    target?.transform = CGAffineTransform(scaleX: 1, y: 1)
-                })
-        } else {
-            if let onTouchBegan = context.getParentClickListener()?.onTouchCanceled {
-                onTouchBegan()
-            }
-        }
-    }
-
-    if target is AnimatedUIControl {
-        let animatedTarget = target as! AnimatedUIControl
-        animatedTarget.setClickListener(clickListener: gesture)
-    }
-
-    return gesture
 }
 
 func isDisabled(requiredFields: [String], values: [String: Any]) -> Bool {

--- a/Sources/Nubrick/Component/context.swift
+++ b/Sources/Nubrick/Component/context.swift
@@ -120,9 +120,6 @@ class UIBlockContext {
         self.container?.formDataPublisher() ?? Just([:]).eraseToAnyPublisher()
     }
 
-    /**
-            propaget onClick gesture to parent
-     */
     func getParentView() -> AnimatedUIView? {
         return self.parentView
     }

--- a/Sources/Nubrick/Component/context.swift
+++ b/Sources/Nubrick/Component/context.swift
@@ -16,7 +16,7 @@ struct UIBlockContextInit {
     var variableStore: VariableStore? = nil
     var properties: [Property]? = nil
     var actionHandler: UIBlockActionHandler? = nil
-    var parentClickListener: ClickListener? = nil
+    var parentView: AnimatedUIView? = nil
     var parentDirection: FlexDirection? = nil
     var layoutInvalidationRoot: UIView? = nil
 }
@@ -26,7 +26,7 @@ struct UIBlockContextChildInit {
     var variableMapper: ((_ variable: Variable?) -> Variable?)? = nil
     var properties: [Property]? = nil
     var actionHandler: UIBlockActionHandler? = nil
-    var parentClickListener: ClickListener? = nil
+    var parentView: AnimatedUIView? = nil
     var parentDirection: FlexDirection? = nil
     var layoutInvalidationRoot: UIView? = nil
 }
@@ -38,7 +38,7 @@ class UIBlockContext {
     private let container: Container?
     private let actionHandler: UIBlockActionHandler?
     private let variableStore: VariableStore
-    private var parentClickListener: ClickListener?
+    private weak var parentView: AnimatedUIView?
     private var parentDirection: FlexDirection?
     private weak var layoutInvalidationRoot: UIView?
 
@@ -46,7 +46,7 @@ class UIBlockContext {
         self.variableStore = args.variableStore ?? VariableStore()
         self.properties = args.properties
         self.actionHandler = args.actionHandler
-        self.parentClickListener = args.parentClickListener
+        self.parentView = args.parentView
         self.parentDirection = args.parentDirection
         self.layoutInvalidationRoot = args.layoutInvalidationRoot
         self.container = args.container
@@ -68,7 +68,7 @@ class UIBlockContext {
                 variableStore: variableStore,
                 properties: args.properties ?? self.properties,
                 actionHandler: args.actionHandler ?? self.actionHandler,
-                parentClickListener: args.parentClickListener ?? self.parentClickListener,
+                parentView: args.parentView ?? self.parentView,
                 parentDirection: args.parentDirection ?? self.parentDirection,
                 layoutInvalidationRoot: args.layoutInvalidationRoot ?? self.layoutInvalidationRoot
             ))
@@ -91,7 +91,7 @@ class UIBlockContext {
     }
 
     func hasParent() -> Bool {
-        return self.parentClickListener != nil
+        return self.parentView != nil
     }
 
     func getParentDireciton() -> FlexDirection? {
@@ -123,14 +123,8 @@ class UIBlockContext {
     /**
             propaget onClick gesture to parent
      */
-    func propagate() {
-        if let onClick = self.parentClickListener?.onClick {
-            onClick()
-        }
-    }
-
-    func getParentClickListener() -> ClickListener? {
-        return self.parentClickListener
+    func getParentView() -> AnimatedUIView? {
+        return self.parentView
     }
 
 }

--- a/Sources/Nubrick/Component/renderer/collection.swift
+++ b/Sources/Nubrick/Component/renderer/collection.swift
@@ -102,12 +102,11 @@ fileprivate func getCollectionLayout(_ block: UICollectionBlock) -> UICollection
     }
 }
 
-class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, BackgroundImageObserver {
+class CollectionView: AnimatedUIView, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, BackgroundImageObserver {
     private let block: UICollectionBlock?
     private let context: UIBlockContext
     private var childrenCount: Int = 0
     private var isReferenced: Bool = false
-    private var gesture: ClickListener? = nil
     private var pageControl: UIPageControl? = nil
     private var collectionView: UICollectionView? = nil
     
@@ -163,13 +162,7 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
             layout.height = .init(value: 100, unit: .percent)
         }
 
-        let gesture = configureOnClickGesture(
-            target: self,
-            selector: #selector(onClicked(sender:)),
-            context: context,
-            uiBlockAction: block.data?.onClick
-        )
-        self.gesture = gesture
+        configureOnClickGesture(context: context, uiBlockAction: block.data?.onClick)
 
         self.configureLayout { layout in
             layout.isEnabled = true
@@ -308,7 +301,7 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
                                 let childData: Any = data.indices.contains(item) ? data[item] : ([:] as [String: Any])
                                 return _replaceVariableData(base: variable, data: childData)
                             },
-                            parentClickListener: self.gesture,
+                            parentView: self,
                             parentDirection: self.block?.data?.direction,
                             layoutInvalidationRoot: cell
                         )
@@ -323,7 +316,7 @@ class CollectionView: AnimatedUIControl, UICollectionViewDataSource, UICollectio
                     data: child,
                     context: self.context.instanciateFrom(
                         UIBlockContextChildInit(
-                            parentClickListener: self.gesture,
+                            parentView: self,
                             parentDirection: self.block?.data?.direction,
                             layoutInvalidationRoot: cell
                         )

--- a/Sources/Nubrick/Component/renderer/flex.swift
+++ b/Sources/Nubrick/Component/renderer/flex.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 internal import YogaKit
 
-class FlexView: AnimatedUIControl, BackgroundImageObserver {
+class FlexView: AnimatedUIView, BackgroundImageObserver {
     private var block: UIFlexContainerBlock = UIFlexContainerBlock()
     private var context: UIBlockContext?
     private var isOverflowView = false
@@ -55,16 +55,14 @@ class FlexView: AnimatedUIControl, BackgroundImageObserver {
                 parentDirection: context.getParentDireciton())
         }
 
-        let gesture = configureOnClickGesture(
-            target: self, selector: #selector(onClicked(sender:)), context: context,
-            uiBlockAction: block.data?.onClick)
+        configureOnClickGesture(context: context, uiBlockAction: block.data?.onClick)
         let children =
             block.data?.children?.map {
                 uiblockToUIView(
                     data: $0,
                     context: context.instanciateFrom(
                         UIBlockContextChildInit(
-                            parentClickListener: gesture,
+                            parentView: self,
                             parentDirection: block.data?.direction
                         )
                     ))
@@ -192,9 +190,6 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
         self.showsHorizontalScrollIndicator = false
         self.isScrollEnabled = (block.data?.overflow == Overflow.SCROLL) ? true : false
         
-        let _ = configureOnClickGesture(
-            target: self, selector: #selector(onClicked(sender:)), context: context,
-            uiBlockAction: block.data?.onClick)
         // Create child context with FlexOverflowView's direction as the parent direction
         let childContext = context.instanciateFrom(
             UIBlockContextChildInit(parentDirection: block.data?.direction)
@@ -230,14 +225,6 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
 
     deinit {
         self.backgroundImageLoadTask?.cancel()
-    }
-
-    @objc func onClicked(sender: ClickListener) {
-        if sender.state == .ended {
-            if let onClick = sender.onClick {
-                onClick()
-            }
-        }
     }
 
     override func layoutSubviews() {

--- a/Sources/Nubrick/Component/renderer/image.swift
+++ b/Sources/Nubrick/Component/renderer/image.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 internal import YogaKit
 
-class ImageView: AnimatedUIControl {
+class ImageView: AnimatedUIView {
     private let image: UIImageView = UIImageView()
     private var block: UIImageBlock = UIImageBlock()
     private var context: UIBlockContext?
@@ -52,12 +52,7 @@ class ImageView: AnimatedUIControl {
         self.addSubview(self.image)
         self.bindVariable()
 
-        _ = configureOnClickGesture(
-            target: self,
-            selector: #selector(onClicked(sender:)),
-            context: context,
-            uiBlockAction: block.data?.onClick
-        )
+        configureOnClickGesture(context: context, uiBlockAction: block.data?.onClick)
 
         makeDisabledStateListener(target: self, context: context, requiredFields: block.data?.onClick?.requiredFields)?.store(in: &cancellables)
     }

--- a/Sources/Nubrick/Component/renderer/text.swift
+++ b/Sources/Nubrick/Component/renderer/text.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 import UIKit
 
-class TextView: AnimatedUIControl, BackgroundImageObserver {
+class TextView: AnimatedUIView, BackgroundImageObserver {
     var label: UILabel = UILabel()
     var block: UITextBlock = UITextBlock()
     var context: UIBlockContext?
@@ -41,12 +41,7 @@ class TextView: AnimatedUIControl, BackgroundImageObserver {
         self.addSubview(label)
         self.bindVariable()
         
-        _ = configureOnClickGesture(
-            target: self,
-            selector: #selector(onClicked(sender:)),
-            context: context,
-            uiBlockAction: block.data?.onClick
-        )
+        configureOnClickGesture(context: context, uiBlockAction: block.data?.onClick)
         
         makeDisabledStateListener(target: self, context: context, requiredFields: block.data?.onClick?.requiredFields)?.store(in: &cancellables)
     }


### PR DESCRIPTION
## Summary

- Replace `AnimatedUIControl: UIControl` with `AnimatedUIView: UIView` — `UIControl` was never used for its actual purpose; the touch overrides work identically on a plain `UIView`
- Remove `ClickListener: UITapGestureRecognizer` — it was only used as a data bag to hold closures; move `onClick`, `onTouchBegan`, `onTouchEnded`, `onTouchCanceled` as direct private properties on `AnimatedUIView`
- Make `configureOnClickGesture` a method on `AnimatedUIView` with only `(context:uiBlockAction:)` parameters, removing the `target` and `selector` indirection; set `cancelsTouchesInView = false` so `touchesEnded` fires on successful tap instead of `touchesCancelled`
- Replace `parentClickListener: ClickListener?` in `UIBlockContext` with `weak var parentView: AnimatedUIView?`; remove dead `propagate()` method
- Remove redundant `onClicked(sender:)` override in `FlexView` and dead `configureOnClickGesture` call in `FlexOverflowView` (whose inner `FlexView` always covers the full tappable area)