### PR TITLE
Remove incorrect padding workaround in flex layout

### DIFF
--- a/Sources/Nubrick/Component/renderer/flex.swift
+++ b/Sources/Nubrick/Component/renderer/flex.swift
@@ -67,11 +67,6 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
                         )
                     ))
             } ?? []
-        // somehow, a container.padding won't work when the container size is 100%.
-        // so we adjust padding virtually with the margin of the last child.
-        let enableAdjustingXAxisPadding = direction == .row && (block.data?.frame?.width == 0)
-        let enableAdjustingYAxisPadding = direction == .column && (block.data?.frame?.height == 0)
-        let lastChildIndex = children.endIndex - 1
         for (index, child) in children.enumerated() {
             child.configureLayout { (layout) in
                 if index != 0 {
@@ -81,19 +76,6 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
                         layout.marginLeft = parseInt(block.data?.gap)
                     } else {
                         layout.marginTop = parseInt(block.data?.gap)
-                    }
-                }
-                if index == lastChildIndex {
-                    if enableAdjustingXAxisPadding {
-                        layout.marginRight = parseInt(
-                            (block.data?.frame?.paddingRight ?? 0)
-                                + (block.data?.frame?.paddingLeft ?? 0))
-
-                    }
-                    if enableAdjustingYAxisPadding {
-                        layout.marginBottom = parseInt(
-                            (block.data?.frame?.paddingTop ?? 0)
-                                + (block.data?.frame?.paddingBottom ?? 0))
                     }
                 }
 


### PR DESCRIPTION
## Summary

- Removes a workaround that faked container padding by injecting margins onto the last child of fill-sized flex containers
- The workaround was based on a false assumption: Yoga does correctly apply padding on fill containers
- With the workaround active, padding was applied twice (once natively by Yoga, once via child margins), causing misaligned children — most visibly, a single child in a vertical flex would appear off-center with extra space below