### PR TITLE
Add survey response tracking with experiment/variant context

### DIFF
--- a/Sources/Nubrick/Component/action-listener.swift
+++ b/Sources/Nubrick/Component/action-listener.swift
@@ -41,6 +41,9 @@ class AnimatedUIView: UIView {
                 self?.isUserInteractionEnabled = false
                 self?.alpha = 0.8
             }
+            if uiBlockAction.submitSurveyResponse == true {
+                context.sendSurveyResponse()
+            }
             context.dispatch(
                 action: compiledAction,
                 onHttpSettled: { [weak self] in
@@ -133,6 +136,7 @@ func compileAction(action: UIBlockAction, variable: Variable?) -> UIBlockAction 
         }),
         requiredFields: action.requiredFields,
         httpRequest: action.httpRequest,
-        httpResponseAssertion: action.httpResponseAssertion
+        httpResponseAssertion: action.httpResponseAssertion,
+        submitSurveyResponse: action.submitSurveyResponse
     )
 }

--- a/Sources/Nubrick/Component/context.swift
+++ b/Sources/Nubrick/Component/context.swift
@@ -115,6 +115,9 @@ class UIBlockContext {
         return self.container?.getFormValues() ?? [:]
     }
 
+    func sendSurveyResponse() {
+        self.container?.sendSurveyResponse()
+    }
 
     func formPublisher() -> AnyPublisher<[String: Any], Never> {
         self.container?.formDataPublisher() ?? Just([:]).eraseToAnyPublisher()

--- a/Sources/Nubrick/Component/embedding.swift
+++ b/Sources/Nubrick/Component/embedding.swift
@@ -61,6 +61,7 @@ class EmbeddingUIView: UIView, NubrickEmbeddingUpdatable {
 
     init(
         experimentId: String,
+        variantId: String? = nil,
         componentId: String? = nil,
         container: Container,
         arguments: NubrickArguments? = nil,
@@ -96,11 +97,13 @@ class EmbeddingUIView: UIView, NubrickEmbeddingUpdatable {
             
             await MainActor.run { [weak self] in
                 switch result {
-                case .success(let view):
-                    switch view {
+                case .success(let fetched):
+                    switch fetched.block {
                     case .EUIRootBlock(let root):
                         let rootView = RootView(
                             root: root,
+                            experimentId: fetched.experimentId ?? experimentId,
+                            variantId: fetched.variantId ?? variantId,
                             container: container,
                             arguments: arguments,
                             modalViewController: modalViewController,
@@ -153,6 +156,8 @@ struct ComponentView: View {
     @State private var height: NubrickSize = .fill
 
     let root: UIRootBlock?
+    let experimentId: String?
+    let variantId: String?
     let container: Container
     let arguments: NubrickArguments?
     let modalViewController: ModalComponentViewController?
@@ -180,6 +185,8 @@ struct ComponentView: View {
     var body: some View {
         RootViewRepresentable(
             root: root,
+            experimentId: experimentId,
+            variantId: variantId,
             container: container,
             arguments: arguments,
             modalViewController: modalViewController,
@@ -204,7 +211,7 @@ public enum SwiftUIEmbeddingPhase {
 
 fileprivate enum FetchState {
     case loading
-    case completed(UIRootBlock)
+    case completed(root: UIRootBlock, experimentId: String?, variantId: String?)
     case notFound
     case failed(Error)
 }
@@ -215,15 +222,20 @@ class EmbeddingSwiftViewModel: ObservableObject {
 
     func fetchEmbeddingAndUpdatePhase(
         experimentId: String,
+        variantId: String? = nil,
         componentId: String? = nil,
         container: Container
     ) async {
         let result = await container.fetchEmbedding(experimentId: experimentId, componentId: componentId)
         switch result {
-        case .success(let view):
-            switch view {
+        case .success(let fetched):
+            switch fetched.block {
             case .EUIRootBlock(let root):
-                self.state = .completed(root)
+                self.state = .completed(
+                    root: root,
+                    experimentId: fetched.experimentId ?? experimentId,
+                    variantId: fetched.variantId ?? variantId
+                )
             default:
                 self.state = .notFound
             }
@@ -240,14 +252,16 @@ class EmbeddingSwiftViewModel: ObservableObject {
 }
 
 struct EmbeddingSwiftView: View {
-    private struct FetchKey: Equatable {
+    private struct FetchKey: Hashable {
         let experimentId: String
+        let variantId: String?
         let componentId: String?
     }
 
     @ViewBuilder private let _content: ((_ phase: SwiftUIEmbeddingPhase) -> AnyView)
     @StateObject private var data = EmbeddingSwiftViewModel()
     private let experimentId: String
+    private let variantId: String?
     private let componentId: String?
     private let container: Container
     private let arguments: NubrickArguments?
@@ -255,24 +269,26 @@ struct EmbeddingSwiftView: View {
     private let onEvent: ((_ event: ComponentEvent) -> Void)?
     private let onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)?
     private var fetchKey: FetchKey {
-        FetchKey(experimentId: experimentId, componentId: componentId)
+        FetchKey(experimentId: experimentId, variantId: variantId, componentId: componentId)
     }
 
     private var phase: SwiftUIEmbeddingPhase {
         switch data.state {
         case .loading:
             return .loading
-        case .completed(let root):
+        case .completed(let root, let resolvedExperimentId, let variantId):
             return .completed(AnyView(
                 ComponentView(
                     root: root,
+                    experimentId: resolvedExperimentId ?? experimentId,
+                    variantId: variantId,
                     container: container,
                     arguments: arguments,
                     modalViewController: modalViewController,
                     onEvent: onEvent,
                     onSizeChange: onSizeChange
                 )
-                .id(root.id)
+                .id(fetchKey)
             ))
         case .notFound:
             return .notFound
@@ -283,6 +299,7 @@ struct EmbeddingSwiftView: View {
     
     init(
         experimentId: String,
+        variantId: String? = nil,
         componentId: String? = nil,
         container: Container,
         arguments: NubrickArguments? = nil,
@@ -291,6 +308,7 @@ struct EmbeddingSwiftView: View {
         onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
         self.experimentId = experimentId
+        self.variantId = variantId
         self.componentId = componentId
         self.container = container
         self.arguments = arguments
@@ -311,6 +329,7 @@ struct EmbeddingSwiftView: View {
 
     init<V: View>(
         experimentId: String,
+        variantId: String? = nil,
         componentId: String? = nil,
         container: Container,
         arguments: NubrickArguments? = nil,
@@ -320,6 +339,7 @@ struct EmbeddingSwiftView: View {
         onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
         self.experimentId = experimentId
+        self.variantId = variantId
         self.componentId = componentId
         self.container = container
         self.arguments = arguments
@@ -339,6 +359,7 @@ struct EmbeddingSwiftView: View {
             .task(id: fetchKey) {
                 await data.fetchEmbeddingAndUpdatePhase(
                     experimentId: experimentId,
+                    variantId: variantId,
                     componentId: componentId,
                     container: container
                 )

--- a/Sources/Nubrick/Component/renderer/select.swift
+++ b/Sources/Nubrick/Component/renderer/select.swift
@@ -200,7 +200,10 @@ class MultiSelectTableViewController: UIViewController, UITableViewDelegate, UIT
             return
         }
         let cellOption = self.options[indexPath.row]
-        if cell.accessoryType == .none {
+        let isSelected = self.selectedOptions.contains { option in
+            option.value == cellOption.value
+        }
+        if !isSelected {
             cell.accessoryType = .checkmark
 
             self.selectedOptions = self.selectedOptions.filter({ option in
@@ -241,9 +244,7 @@ class MultiSelectTableViewController: UIViewController, UITableViewDelegate, UIT
                return false
            }
         })
-        if selectedCellOption != nil {
-            cell.accessoryType = .checkmark
-        }
+        cell.accessoryType = selectedCellOption != nil ? .checkmark : .none
 
         return cell
     }

--- a/Sources/Nubrick/Component/root.swift
+++ b/Sources/Nubrick/Component/root.swift
@@ -18,7 +18,11 @@ class ModalRootViewController: UIViewController {
     private let container: Container
 
     init(
-        root: UIRootBlock?, container: Container, modalViewController: ModalComponentViewController?
+        root: UIRootBlock?,
+        experimentId: String? = nil,
+        variantId: String? = nil,
+        container: Container,
+        modalViewController: ModalComponentViewController?
     ) {
         self.pages = root?.data?.pages ?? []
         let trigger = self.pages.first { page in
@@ -26,7 +30,10 @@ class ModalRootViewController: UIViewController {
         }
         self.modalViewController = modalViewController
         self.modalViewController?.dismissModal()
-        self.container = container.makeContainer()
+        self.container = container.makeContainer(
+            experimentId: experimentId ?? container.experimentId,
+            variantId: variantId ?? container.variantId
+        )
         super.init(nibName: nil, bundle: nil)
 
         self.actionHandler = { [weak self] action, _ in
@@ -136,6 +143,8 @@ class ModalRootViewController: UIViewController {
 struct RootViewRepresentable: UIViewRepresentable {
     typealias UIViewType = RootView
     let root: UIRootBlock?
+    let experimentId: String?
+    let variantId: String?
     let container: Container
     let arguments: NubrickArguments?
     let modalViewController: ModalComponentViewController?
@@ -186,6 +195,8 @@ struct RootViewRepresentable: UIViewRepresentable {
         }
         return RootView(
             root: root,
+            experimentId: experimentId,
+            variantId: variantId,
             container: container,
             arguments: arguments,
             modalViewController: modalViewController,
@@ -231,6 +242,8 @@ class RootView: UIView {
 
     init(
         root: UIRootBlock?,
+        experimentId: String? = nil,
+        variantId: String? = nil,
         container: Container,
         arguments: NubrickArguments? = nil,
         modalViewController: ModalComponentViewController?,
@@ -240,7 +253,10 @@ class RootView: UIView {
         onSizeChange: ((_ width: NubrickSize, _ height: NubrickSize) -> Void)? = nil
     ) {
         self.id = root?.id ?? ""
-        self.container = container.makeContainer()
+        self.container = container.makeContainer(
+            experimentId: experimentId ?? container.experimentId,
+            variantId: variantId ?? container.variantId
+        )
         self.arguments = arguments
         self.pages = root?.data?.pages ?? []
         let trigger = self.pages.first { page in

--- a/Sources/Nubrick/Component/trigger.swift
+++ b/Sources/Nubrick/Component/trigger.swift
@@ -117,15 +117,18 @@ class TriggerViewController: UIViewController {
             let kinds: [ExperimentKind] = self.onTooltip != nil ? [.POPUP, .TOOLTIP] : [.POPUP]
             let triggerResult = await self.container.fetchTriggerContent(trigger: event.name, kinds: kinds)
             let experimentId: String?
+            let variantId: String?
             let kind: ExperimentKind?
             let result: Result<UIBlock, NubrickError>
             switch triggerResult {
-            case .success(let (id, k, block)):
-                experimentId = id
-                kind = k
-                result = .success(block)
+            case .success(let content):
+                experimentId = content.experimentId
+                variantId = content.variantId
+                kind = content.kind
+                result = .success(content.block)
             case .failure(let error):
                 experimentId = nil
+                variantId = nil
                 kind = nil
                 result = .failure(error)
             }
@@ -154,6 +157,8 @@ class TriggerViewController: UIViewController {
                         } else {
                             let root = ModalRootViewController(
                                 root: root,
+                                experimentId: experimentId,
+                                variantId: variantId,
                                 container: self.container,
                                 modalViewController: self.modalViewController
                             )

--- a/Sources/Nubrick/Data/container.swift
+++ b/Sources/Nubrick/Data/container.swift
@@ -181,7 +181,7 @@ final class ContainerImpl: Container {
             switch await self.componentRepository.fetchComponent(experimentId: experimentId, id: componentId) {
             case .success(let block):
                 return .success(FetchedEmbedding(
-                    experimentId: self.experimentId,
+                    experimentId: experimentId,
                     variantId: self.variantId,
                     block: block
                 ))

--- a/Sources/Nubrick/Data/container.swift
+++ b/Sources/Nubrick/Data/container.swift
@@ -14,11 +14,29 @@ private struct ExtractedVariant {
     let variant: ExperimentVariant
 }
 
+struct FetchedEmbedding {
+    let experimentId: String?
+    let variantId: String?
+    let block: UIBlock
+}
+
+struct FetchedTriggerContent {
+    let experimentId: String
+    let variantId: String
+    let kind: ExperimentKind?
+    let block: UIBlock
+}
+
 protocol Container : Sendable {
+    var experimentId: String? { get }
+    var variantId: String? { get }
+
     @MainActor
     func handleEvent(_ it: UIBlockAction)
     @MainActor
     func makeContainer() -> Container
+    @MainActor
+    func makeContainer(experimentId: String?, variantId: String?) -> Container
     @MainActor
     func createVariableForTemplate(data: Any?, properties: [Property]?, arguments: NubrickArguments?) -> Variable?
     @MainActor
@@ -28,17 +46,21 @@ protocol Container : Sendable {
     @MainActor
     func setFormValue(key: String, value: Any)
     @MainActor
+    func sendSurveyResponse()
+    @MainActor
     func formDataPublisher() -> AnyPublisher<[String: Any], Never>
     @MainActor
     func userDataPublisher() -> AnyPublisher<[String: Any], Never>
 
     func sendHttpRequest(req: ApiHttpRequest, assertion: ApiHttpResponseAssertion?, variable: Variable?) async -> Result<JSONData, NubrickError>
-    func fetchEmbedding(experimentId: String, componentId: String?) async -> Result<UIBlock, NubrickError>
-    func fetchTriggerContent(trigger: String, kinds: [ExperimentKind]) async -> Result<(String, ExperimentKind?, UIBlock), NubrickError>
+    func fetchEmbedding(experimentId: String, componentId: String?) async -> Result<FetchedEmbedding, NubrickError>
+    func fetchTriggerContent(trigger: String, kinds: [ExperimentKind]) async -> Result<FetchedTriggerContent, NubrickError>
     func fetchRemoteConfig(experimentId: String) async -> Result<(String, ExperimentVariant), NubrickError>
 }
 
 final class ContainerImpl: Container {
+    let experimentId: String?
+    let variantId: String?
     private let config: Config
     private let user: NubrickUser
     private let actionHandler: UIBlockActionHandler
@@ -58,8 +80,12 @@ final class ContainerImpl: Container {
         componentRepository: ComponentRepository2,
         trackRepository: TrackRepository2,
         databaseRepository: DatabaseRepository,
-        httpRequestRepository: HttpRequestRepository
+        httpRequestRepository: HttpRequestRepository,
+        experimentId: String? = nil,
+        variantId: String? = nil
     ) {
+        self.experimentId = experimentId
+        self.variantId = variantId
         self.config = config
         self.user = user
         self.actionHandler = actionHandler
@@ -78,6 +104,11 @@ final class ContainerImpl: Container {
 
     @MainActor
     func makeContainer() -> Container {
+        makeContainer(experimentId: experimentId, variantId: variantId)
+    }
+
+    @MainActor
+    func makeContainer(experimentId: String?, variantId: String?) -> Container {
         return ContainerImpl(
             config: self.config,
             user: self.user,
@@ -86,7 +117,9 @@ final class ContainerImpl: Container {
             componentRepository: self.componentRepository,
             trackRepository: self.trackRepository,
             databaseRepository: self.databaseRepository,
-            httpRequestRepository: self.httpRequestRepository
+            httpRequestRepository: self.httpRequestRepository,
+            experimentId: experimentId,
+            variantId: variantId
         )
     }
 
@@ -143,10 +176,18 @@ final class ContainerImpl: Container {
 
     // MARK: - Experiment Content
 
-    func fetchEmbedding(experimentId: String, componentId: String? = nil) async -> Result<UIBlock, NubrickError> {
+    func fetchEmbedding(experimentId: String, componentId: String? = nil) async -> Result<FetchedEmbedding, NubrickError> {
         if let componentId = componentId {
-            let component = await self.componentRepository.fetchComponent(experimentId: experimentId, id: componentId)
-            return component
+            switch await self.componentRepository.fetchComponent(experimentId: experimentId, id: componentId) {
+            case .success(let block):
+                return .success(FetchedEmbedding(
+                    experimentId: self.experimentId,
+                    variantId: self.variantId,
+                    block: block
+                ))
+            case .failure(let error):
+                return .failure(error)
+            }
         }
 
         var configs: ExperimentConfigs
@@ -178,10 +219,19 @@ final class ContainerImpl: Container {
             return Result.failure(NubrickError.notFound)
         }
 
-        return await self.componentRepository.fetchComponent(experimentId: extracted.experimentId, id: componentId)
+        switch await self.componentRepository.fetchComponent(experimentId: extracted.experimentId, id: componentId) {
+        case .success(let block):
+            return .success(FetchedEmbedding(
+                experimentId: extracted.experimentId,
+                variantId: variantId,
+                block: block
+            ))
+        case .failure(let error):
+            return .failure(error)
+        }
     }
 
-    func fetchTriggerContent(trigger: String, kinds: [ExperimentKind]) async -> Result<(String, ExperimentKind?, UIBlock), NubrickError> {
+    func fetchTriggerContent(trigger: String, kinds: [ExperimentKind]) async -> Result<FetchedTriggerContent, NubrickError> {
         await self.trackRepository.trackEvent(TrackUserEvent(name: trigger))
         await self.databaseRepository.appendUserEvent(name: trigger)
 
@@ -220,7 +270,12 @@ final class ContainerImpl: Container {
 
         switch await self.componentRepository.fetchComponent(experimentId: extracted.experimentId, id: componentId) {
         case .success(let block):
-            return .success((extracted.experimentId, extracted.kind, block))
+            return .success(FetchedTriggerContent(
+                experimentId: extracted.experimentId,
+                variantId: variantId,
+                kind: extracted.kind,
+                block: block
+            ))
         case .failure(let error):
             return .failure(error)
         }
@@ -287,5 +342,23 @@ final class ContainerImpl: Container {
             return Result.failure(NubrickError.notFound)
         }
         return Result.success(ExtractedVariant(experimentId: experimentId, kind: config.kind, variant: variant))
+    }
+
+    @MainActor
+    func sendSurveyResponse() {
+        guard let experimentId, let variantId else {
+            return
+        }
+        guard let response_data = try? makeJsonString(self.formRepository.getFormData()) else {
+            return
+        }
+        let trackRepository = self.trackRepository
+        Task {
+            await trackRepository.sendSurveyResponse(
+                experimentId: experimentId,
+                variantId: variantId,
+                response_data: response_data
+            )
+        }
     }
 }

--- a/Sources/Nubrick/Data/track.swift
+++ b/Sources/Nubrick/Data/track.swift
@@ -156,6 +156,17 @@ protocol TrackRepository2 : Actor {
     )
 
     func sendFlutterCrash(_ crashEvent: TrackCrashEvent)
+    func sendSurveyResponse(experimentId: String, variantId: String, response_data: String) async
+}
+
+struct SurveyResponseRequest: Encodable {
+    var timestamp: DateTime
+    var projectId: String
+    var experimentId: String
+    var variantId: String
+    var userId: String
+    var response_data: String
+    var meta: TrackEventMeta
 }
 
 struct TrackRequest: Encodable {
@@ -198,6 +209,18 @@ struct TrackEventMeta: Encodable {
     var osVersion: String?
     var sdkVersion: String?
     var platform: String? = "ios"
+
+    @MainActor
+    static func current() -> TrackEventMeta {
+        TrackEventMeta(
+            appId: Bundle.main.bundleIdentifier ?? "",
+            appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
+            cfBundleVersion: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "",
+            osName: UIDevice.current.systemName,
+            osVersion: UIDevice.current.systemVersion,
+            sdkVersion: NubrickConstants.sdkVersion
+        )
+    }
 }
 
 struct TrackUserEvent {
@@ -212,6 +235,11 @@ struct TrackExperimentEvent {
 // Convert UInt64 to hex string
 private func hex(_ v: UInt64) -> String {
     String(format: "0x%016llx", v)
+}
+
+func makeJsonString(_ value: Any) throws -> String {
+    let data = try JSONEncoder().encode(JSON(value: value))
+    return String(data: data, encoding: .utf8) ?? "null"
 }
 
 /// Compute image_addr (load address) from a MetricKit frame.
@@ -238,7 +266,18 @@ actor TrackRespositoryImpl: TrackRepository2 {
         self.buffer = []
         self.flushTask = nil
     }
-    
+
+    private func makeJsonRequest<Body: Encodable>(
+        url: URL,
+        body: Body
+    ) throws -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(body)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        return request
+    }
+
     func trackExperimentEvent(_ event: TrackExperimentEvent) {
         self.pushToQueue(TrackEvent(
             typename: .Experiment,
@@ -296,17 +335,6 @@ actor TrackRespositoryImpl: TrackRepository2 {
         let events = self.buffer
         self.buffer = []
 
-        let appId = Bundle.main.bundleIdentifier ?? ""
-        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-        let cfBundleVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
-        let trackMeta = await TrackEventMeta(
-            appId: appId,
-            appVersion: appVersion,
-            cfBundleVersion: cfBundleVersion,
-            osName: UIDevice.current.systemName,
-            osVersion: UIDevice.current.systemVersion,
-            sdkVersion: NubrickConstants.sdkVersion
-        )
         let userID = await MainActor.run {
             self.user.id
         }
@@ -315,16 +343,12 @@ actor TrackRespositoryImpl: TrackRepository2 {
             userId: userID,
             timestamp: getCurrentDate().ISO8601Format(),
             events: events,
-            meta: trackMeta
+            meta: await TrackEventMeta.current()
         )
 
         do {
             let url = URL(string: config.trackUrl)!
-            let jsonData = try JSONEncoder().encode(trackRequest)
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            request.httpBody = jsonData
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let request = try makeJsonRequest(url: url, body: trackRequest)
             let _ = try await nativebrikSession.data(for: request)
         } catch {
             self.buffer.append(contentsOf: events)
@@ -457,5 +481,32 @@ actor TrackRespositoryImpl: TrackRepository2 {
 
     func sendFlutterCrash(_ crashEvent: TrackCrashEvent) {
         sendCrashToBackend(crashEvent)
+    }
+
+    func sendSurveyResponse(experimentId: String, variantId: String, response_data: String) async {
+        guard !experimentId.isEmpty, !variantId.isEmpty else {
+            return
+        }
+        let userID = await MainActor.run {
+            self.user.id
+        }
+
+        do {
+            let requestBody = SurveyResponseRequest(
+                timestamp: getCurrentDate().ISO8601Format(),
+                projectId: self.config.projectId,
+                experimentId: experimentId,
+                variantId: variantId,
+                userId: userID,
+                response_data: response_data,
+                meta: await TrackEventMeta.current()
+            )
+            let url = URL(string: config.surveyResponsesUrl)!
+            let request = try makeJsonRequest(url: url, body: requestBody)
+            let _ = try await nativebrikSession.data(for: request)
+        } catch {
+            // Form submissions are one-shot; keep the event pipeline unaffected on failure.
+            return
+        }
     }
 }

--- a/Sources/Nubrick/Schema/generated.swift
+++ b/Sources/Nubrick/Schema/generated.swift
@@ -576,6 +576,7 @@ struct UIBlockAction: Decodable, Encodable {
   var requiredFields: [String]?
   var httpRequest: ApiHttpRequest?
   var httpResponseAssertion: ApiHttpResponseAssertion?
+  var submitSurveyResponse: Boolean?
 }
 struct UICarouselBlock: Decodable, Encodable {
   var id: ID?

--- a/Sources/Nubrick/constants.swift
+++ b/Sources/Nubrick/constants.swift
@@ -3,7 +3,11 @@ import Foundation
 private final class NubrickBundleToken {}
 
 enum NubrickConstants {
-    static let trackUrl = "https://track.nativebrik.com/track/v1"
+    static let trackBaseUrl = "https://track.nativebrik.com"
+    static let trackEndpoint = "/track/v1"
+    static let surveyResponsesEndpoint = "/track/v1/survey-responses"
+    static let trackUrl = "\(trackBaseUrl)\(trackEndpoint)"
+    static let surveyResponsesUrl = "\(trackBaseUrl)\(surveyResponsesEndpoint)"
     static let cdnUrl = "https://cdn.nativebrik.com"
 
     // Prefer the framework bundle version so release metadata comes from build settings.

--- a/Sources/Nubrick/remote-config.swift
+++ b/Sources/Nubrick/remote-config.swift
@@ -90,6 +90,7 @@ public final class RemoteConfigVariant : Sendable {
         let componentId = self.get(key)
         return EmbeddingSwiftView(
             experimentId: self.experimentId,
+            variantId: self.variantId,
             componentId: componentId,
             container: self.container,
             arguments: arguments,
@@ -108,6 +109,7 @@ public final class RemoteConfigVariant : Sendable {
         let componentId = self.get(key)
         return EmbeddingSwiftView(
             experimentId: self.experimentId,
+            variantId: self.variantId,
             componentId: componentId,
             container: self.container,
             arguments: arguments,
@@ -128,6 +130,7 @@ public final class RemoteConfigVariant : Sendable {
         }
         let uiview = EmbeddingUIView(
             experimentId: self.experimentId,
+            variantId: self.variantId,
             componentId: componentId,
             container: self.container,
             arguments: arguments,
@@ -150,6 +153,7 @@ public final class RemoteConfigVariant : Sendable {
         }
         let uiview = EmbeddingUIView(
             experimentId: self.experimentId,
+            variantId: self.variantId,
             componentId: componentId,
             container: self.container,
             arguments: arguments,

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -81,11 +81,13 @@ private func dispatchMainActor(_ event: NubrickEvent) {
 final class Config : Sendable{
     let projectId: String
     let trackUrl: String
+    let surveyResponsesUrl: String
     let cdnUrl: String
 
     init(projectId: String) {
         self.projectId = projectId
         self.trackUrl = NubrickConstants.trackUrl
+        self.surveyResponsesUrl = NubrickConstants.surveyResponsesUrl
         self.cdnUrl = NubrickConstants.cdnUrl
     }
 }


### PR DESCRIPTION
## Summary
- Adds a `submitSurveyResponse` action flag that triggers `Container.sendSurveyResponse()`, posting form data to a new `/track/v1/survey-responses` endpoint.
- Threads `experimentId`/`variantId` through embeddings, triggers, and `Container` (`makeContainer`, `fetchEmbedding`, `fetchTriggerContent`) so survey responses and nested modals carry the correct experiment/variant context.
- Refactors `TrackRepository2` to share a `makeJsonRequest` helper and a `TrackEventMeta.current()` factory.