### PR TITLE
Fix action state handling and survey response dispatch

### DIFF
--- a/Sources/Nubrick/Component/action-listener.swift
+++ b/Sources/Nubrick/Component/action-listener.swift
@@ -14,6 +14,32 @@ class AnimatedUIView: UIView {
     private var onTouchBegan: (() -> Void)?
     private var onTouchEnded: (() -> Void)?
     private var onTouchCanceled: (() -> Void)?
+    private var isRequestPending = false
+    private var hasInvalidRequiredFields = false
+
+    @MainActor
+    func setRequestPending(_ pending: Bool) {
+        isRequestPending = pending
+        updateActionState()
+    }
+
+    @MainActor
+    func setRequiredFieldsInvalid(_ invalid: Bool) {
+        hasInvalidRequiredFields = invalid
+        updateActionState()
+    }
+
+    @MainActor
+    private func updateActionState() {
+        isUserInteractionEnabled = !isRequestPending && !hasInvalidRequiredFields
+        if hasInvalidRequiredFields {
+            alpha = 0.5
+        } else if isRequestPending {
+            alpha = 0.8
+        } else {
+            alpha = 1
+        }
+    }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
@@ -38,17 +64,12 @@ class AnimatedUIView: UIView {
             guard let uiBlockAction = uiBlockAction else { return }
             let compiledAction = compileAction(action: uiBlockAction, context: context)
             if uiBlockAction.httpRequest != nil {
-                self?.isUserInteractionEnabled = false
-                self?.alpha = 0.8
-            }
-            if uiBlockAction.submitSurveyResponse == true {
-                context.sendSurveyResponse()
+                self?.setRequestPending(true)
             }
             context.dispatch(
                 action: compiledAction,
                 onHttpSettled: { [weak self] in
-                    self?.isUserInteractionEnabled = true
-                    self?.alpha = 1
+                    self?.setRequestPending(false)
                 }
             )
         }
@@ -89,11 +110,22 @@ class AnimatedUIView: UIView {
 }
 
 func isDisabled(requiredFields: [String], values: [String: Any]) -> Bool {
-    return requiredFields.contains {
-        if let value = values[$0] as? String {
-            return value.isEmpty
+    return requiredFields.contains { field in
+        guard let value = values[field] else {
+            return true
         }
-        return false
+        switch value {
+        case let value as String:
+            return value.isEmpty
+        case let value as [String]:
+            return value.isEmpty
+        case let value as [Any]:
+            return value.isEmpty
+        case is NSNull:
+            return true
+        default:
+            return false
+        }
     }
 }
 
@@ -105,8 +137,12 @@ func makeDisabledStateListener(target: UIView, context: UIBlockContext, required
         .removeDuplicates()
         .sink { [weak target] disabled in
             guard let target else { return }
-            target.isUserInteractionEnabled = !disabled
-            target.alpha = disabled ? 0.5 : 1.0
+            if let target = target as? AnimatedUIView {
+                target.setRequiredFieldsInvalid(disabled)
+            } else {
+                target.isUserInteractionEnabled = !disabled
+                target.alpha = disabled ? 0.5 : 1.0
+            }
         }
 }
 

--- a/Sources/Nubrick/Component/context.swift
+++ b/Sources/Nubrick/Component/context.swift
@@ -115,10 +115,6 @@ class UIBlockContext {
         return self.container?.getFormValues() ?? [:]
     }
 
-    func sendSurveyResponse() {
-        self.container?.sendSurveyResponse()
-    }
-
     func formPublisher() -> AnyPublisher<[String: Any], Never> {
         self.container?.formDataPublisher() ?? Just([:]).eraseToAnyPublisher()
     }

--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -135,7 +135,7 @@ final class PageView: UIView {
         props: [Property]?,
         container: Container,
         arguments: NubrickArguments?,
-        actionHandler: UIBlockActionHandler?,
+        actionHandler parentActionHandler: UIBlockActionHandler?,
         modalViewController: ModalComponentViewController?
     ) {
         self.page = page
@@ -174,36 +174,22 @@ final class PageView: UIView {
 
             let variable = self.currentVariable()
 
+            let httpRequest = action.httpRequest
             let assertion = action.httpResponseAssertion
-            let forwardAction = { () -> Void in
-                Task { @MainActor in
-                    actionHandler?(action, nil)
-                }
-            }
+            let container = self.container
 
-            if let httpRequest = action.httpRequest {
-                Task { [weak self] in
-                    guard let self else {
-                        return
-                    }
-                    let result = await self.container.sendHttpRequest(
+            if let httpRequest {
+                Task {
+                    _ = await container.sendHttpRequest(
                         req: httpRequest,
                         assertion: assertion,
                         variable: variable
                     )
-                    switch result {
-                    case .success:
-                        await MainActor.run { onHttpSettled?() }
-                        forwardAction()
-                    case .failure:
-                        await MainActor.run { onHttpSettled?() }
-                        // TODO: handle error
-                        forwardAction()
-                    }
+                    await MainActor.run { onHttpSettled?() }
                 }
-            } else {
-                forwardAction()
             }
+
+            parentActionHandler?(action, nil)
         }
 
         // setup layout

--- a/Sources/Nubrick/Component/renderer/flex.swift
+++ b/Sources/Nubrick/Component/renderer/flex.swift
@@ -201,8 +201,6 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
            let template = self.block.data?.frame?.backgroundSrc {
             observeBackgroundImage(context: context, urlTemplate: template)
         }
-        
-        makeDisabledStateListener(target: self, context: context, requiredFields: block.data?.onClick?.requiredFields)?.store(in: &cancellables)
     }
 
     deinit {

--- a/Sources/Nubrick/Data/container.swift
+++ b/Sources/Nubrick/Data/container.swift
@@ -46,8 +46,6 @@ protocol Container : Sendable {
     @MainActor
     func setFormValue(key: String, value: Any)
     @MainActor
-    func sendSurveyResponse()
-    @MainActor
     func formDataPublisher() -> AnyPublisher<[String: Any], Never>
     @MainActor
     func userDataPublisher() -> AnyPublisher<[String: Any], Never>
@@ -99,6 +97,9 @@ final class ContainerImpl: Container {
 
     @MainActor
     func handleEvent(_ it: UIBlockAction) {
+        if it.submitSurveyResponse == true {
+            self.sendSurveyResponse()
+        }
         self.actionHandler(it, nil)
     }
 
@@ -345,7 +346,7 @@ final class ContainerImpl: Container {
     }
 
     @MainActor
-    func sendSurveyResponse() {
+    private func sendSurveyResponse() {
         guard let experimentId, let variantId else {
             return
         }

--- a/Tests/NubrickTests/Component/action-listener.swift
+++ b/Tests/NubrickTests/Component/action-listener.swift
@@ -1,0 +1,51 @@
+import Foundation
+import XCTest
+@testable import NubrickLocal
+
+final class ActionListenerTests: XCTestCase {
+    func testRequiredFieldsTreatMissingAndEmptyValuesAsDisabled() {
+        XCTAssertTrue(isDisabled(requiredFields: ["answer"], values: [:]))
+        XCTAssertTrue(isDisabled(requiredFields: ["answer"], values: ["answer": ""]))
+        XCTAssertTrue(isDisabled(requiredFields: ["answer"], values: ["answer": [String]()]))
+        XCTAssertTrue(isDisabled(requiredFields: ["answer"], values: ["answer": NSNull()]))
+    }
+
+    func testRequiredFieldsTreatPresentValuesAsEnabled() {
+        XCTAssertFalse(isDisabled(requiredFields: ["answer"], values: ["answer": "yes"]))
+        XCTAssertFalse(isDisabled(requiredFields: ["answer"], values: ["answer": ["yes"]]))
+        XCTAssertFalse(isDisabled(requiredFields: ["answer"], values: ["answer": false]))
+    }
+
+    @MainActor
+    func testRequestCompletionDoesNotOverrideInvalidRequiredFields() {
+        let view = AnimatedUIView()
+
+        view.setRequestPending(true)
+        XCTAssertFalse(view.isUserInteractionEnabled)
+        XCTAssertEqual(view.alpha, 0.8, accuracy: 0.001)
+
+        view.setRequiredFieldsInvalid(true)
+        XCTAssertFalse(view.isUserInteractionEnabled)
+        XCTAssertEqual(view.alpha, 0.5, accuracy: 0.001)
+
+        view.setRequestPending(false)
+        XCTAssertFalse(view.isUserInteractionEnabled)
+        XCTAssertEqual(view.alpha, 0.5, accuracy: 0.001)
+
+        view.setRequiredFieldsInvalid(false)
+        XCTAssertTrue(view.isUserInteractionEnabled)
+        XCTAssertEqual(view.alpha, 1, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testValidationDoesNotEnableViewWhileRequestIsPending() {
+        let view = AnimatedUIView()
+
+        view.setRequestPending(true)
+        view.setRequiredFieldsInvalid(true)
+        view.setRequiredFieldsInvalid(false)
+
+        XCTAssertFalse(view.isUserInteractionEnabled)
+        XCTAssertEqual(view.alpha, 0.8, accuracy: 0.001)
+    }
+}

--- a/Tests/NubrickTests/Data/repository.swift
+++ b/Tests/NubrickTests/Data/repository.swift
@@ -8,9 +8,54 @@
 import Foundation
 
 import XCTest
-@testable import NubrickLocal
+@_spi(FlutterBridge) @testable import NubrickLocal
 
 let HEALTH_CHECK_URL = "https://track.nativebrik.com/health"
+
+private actor SurveyResponseTrackRepositorySpy: TrackRepository2 {
+    struct Response {
+        let experimentId: String
+        let variantId: String
+        let data: String
+    }
+
+    private var responses: [Response] = []
+    private var responseWaiters: [CheckedContinuation<Response, Never>] = []
+
+    func trackExperimentEvent(_ event: TrackExperimentEvent) {}
+
+    func trackEvent(_ event: TrackUserEvent) {}
+
+    func processMetricKitCrash(
+        callStackTreeJSON: Data,
+        terminationReason: String?,
+        exceptionType: UInt32?
+    ) {}
+
+    func sendFlutterCrash(_ crashEvent: TrackCrashEvent) {}
+
+    func sendSurveyResponse(experimentId: String, variantId: String, response_data: String) async {
+        let response = Response(
+            experimentId: experimentId,
+            variantId: variantId,
+            data: response_data
+        )
+        if responseWaiters.isEmpty {
+            responses.append(response)
+        } else {
+            responseWaiters.removeFirst().resume(returning: response)
+        }
+    }
+
+    func nextResponse() async -> Response {
+        if !responses.isEmpty {
+            return responses.removeFirst()
+        }
+        return await withCheckedContinuation { continuation in
+            responseWaiters.append(continuation)
+        }
+    }
+}
 
 final class HttpRequestReposotiryTests: XCTestCase {
     func testShouldCallApiHttpRequest() throws {
@@ -107,5 +152,49 @@ final class ContainerTests: XCTestCase {
         let childEmailAfter = child.getFormValue(key: "email") as? String
         XCTAssertEqual("root@example.com", rootEmailAfter)
         XCTAssertEqual("child@example.com", childEmailAfter)
+    }
+
+    func testHandleEventSubmitsSurveyResponseWhenRequested() async throws {
+        let db = try XCTUnwrap(createNativebrikCoreDataHelper(), "Could not init DB")
+        let user = NubrickUser()
+        let config = Config(projectId: PROJECT_ID_FOR_TEST)
+        let trackRepository = SurveyResponseTrackRepositorySpy()
+        var handledAction: UIBlockAction?
+        let container = ContainerImpl(
+            config: config,
+            user: user,
+            actionHandler: { action, _ in handledAction = action },
+            experimentRepository: ExperimentRepositoryImpl(config: config),
+            componentRepository: ComponentRepositoryImpl(config: config),
+            trackRepository: trackRepository,
+            databaseRepository: DatabaseRepositoryImpl(persistentContainer: db),
+            httpRequestRepository: HttpRequestRepositoryImpl(),
+            experimentId: "experiment-id",
+            variantId: "variant-id"
+        )
+        container.setFormValue(key: "answer", value: "yes")
+        let action = UIBlockAction(
+            eventName: "survey-submitted",
+            name: nil,
+            destinationPageId: nil,
+            deepLink: nil,
+            payload: nil,
+            requiredFields: nil,
+            httpRequest: nil,
+            httpResponseAssertion: nil,
+            submitSurveyResponse: true
+        )
+
+        container.handleEvent(action)
+
+        let response = await trackRepository.nextResponse()
+        XCTAssertEqual(response.experimentId, "experiment-id")
+        XCTAssertEqual(response.variantId, "variant-id")
+        let responseData = try XCTUnwrap(response.data.data(using: .utf8))
+        let responseJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: responseData) as? [String: String]
+        )
+        XCTAssertEqual(responseJSON, ["answer": "yes"])
+        XCTAssertEqual(handledAction?.eventName, "survey-submitted")
     }
 }


### PR DESCRIPTION
## Summary

- Decouple the action button's two disabled states — in-flight HTTP request vs. invalid required fields — in `AnimatedUIView`. Previously an HTTP request completing (`onHttpSettled`) would re-enable the view even when required fields were still invalid, and vice versa. State is now tracked independently via `setRequestPending` / `setRequiredFieldsInvalid`, with a single `updateActionState` deriving interaction/alpha.
- Broaden `isDisabled(requiredFields:values:)` to correctly treat missing values, empty arrays, and `NSNull` as invalid (not just empty strings).
- Route `makeDisabledStateListener` through the new `AnimatedUIView` state API so validation no longer clobbers request-pending state.
- Move survey response submission into `ContainerImpl.handleEvent` (triggered by `submitSurveyResponse`), removing the separate `sendSurveyResponse` hop through `UIBlockContext` and the `Container` protocol. `sendSurveyResponse` is now private.
- Simplify `PageView`'s action dispatch: fire the HTTP request and settle callback without gating the forwarded action on the request result.
- Remove the redundant disabled-state listener wiring from `FlexOverflowView`.

## Tests

- Add `ActionListenerTests` covering `isDisabled` value handling and the independent request/validation state transitions.
- Add a `ContainerImpl.handleEvent` test verifying a survey response is dispatched with the correct experiment/variant/form data.