### PR TITLE
Pass tooltip variant context through Flutter bridge

### DIFF
--- a/Sources/Nubrick/Component/overlay.swift
+++ b/Sources/Nubrick/Component/overlay.swift
@@ -17,7 +17,7 @@ class OverlayViewController: UIViewController {
         user: NubrickUser,
         container: Container,
         onDispatch: ((_ event: NubrickEvent) -> Void)? = nil,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)? = nil
+        onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)? = nil
     ) {
         self.triggerViewController = TriggerViewController(
             user: user,
@@ -43,7 +43,7 @@ class OverlayViewController: UIViewController {
 
     func updateCallbacks(
         onDispatch: ((_ event: NubrickEvent) -> Void)?,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+        onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)?
     ) {
         self.triggerViewController.updateCallbacks(
             onDispatch: onDispatch,

--- a/Sources/Nubrick/Component/trigger.swift
+++ b/Sources/Nubrick/Component/trigger.swift
@@ -19,7 +19,7 @@ class TriggerViewController: UIViewController {
     private var modalViewController: ModalComponentViewController? = nil
     private var currentVC: ModalRootViewController? = nil
     private var onDispatch: ((_ event: NubrickEvent) -> Void)? = nil
-    private var onTooltip: ((_ data: String, _ experimentId: String) -> Void)? = nil
+    private var onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)? = nil
     private var didLoaded = false
     private var ignoreFirstUserEventToForegroundEvent = true
 
@@ -33,7 +33,7 @@ class TriggerViewController: UIViewController {
         container: Container,
         modalViewController: ModalComponentViewController?,
         onDispatch: ((_ event: NubrickEvent) -> Void)? = nil,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)? = nil
+        onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)? = nil
     ) {
         self.user = user
         self.container = container
@@ -45,7 +45,7 @@ class TriggerViewController: UIViewController {
 
     func updateCallbacks(
         onDispatch: ((_ event: NubrickEvent) -> Void)?,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+        onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)?
     ) {
         if let onDispatch {
             self.onDispatch = onDispatch
@@ -152,7 +152,7 @@ class TriggerViewController: UIViewController {
                            let experimentId = experimentId {
                             if let jsonData = try? JSONEncoder().encode(block),
                                let jsonString = String(data: jsonData, encoding: .utf8) {
-                                onTooltip(jsonString, experimentId)
+                                onTooltip(jsonString, experimentId, variantId)
                             }
                         } else {
                             let root = ModalRootViewController(

--- a/Sources/Nubrick/Component/trigger.swift
+++ b/Sources/Nubrick/Component/trigger.swift
@@ -112,70 +112,70 @@ class TriggerViewController: UIViewController {
     @MainActor
     func dispatch(event: NubrickEvent) {
         Task {
-            // onTooltip is only set in the Flutter SDK. Tooltips are a Flutter-only feature,
-            // so we fetch both popups and tooltips when running in Flutter, and popups only otherwise.
-            let kinds: [ExperimentKind] = self.onTooltip != nil ? [.POPUP, .TOOLTIP] : [.POPUP]
-            let triggerResult = await self.container.fetchTriggerContent(trigger: event.name, kinds: kinds)
-            let experimentId: String?
-            let variantId: String?
-            let kind: ExperimentKind?
-            let result: Result<UIBlock, NubrickError>
-            switch triggerResult {
-            case .success(let content):
-                experimentId = content.experimentId
-                variantId = content.variantId
-                kind = content.kind
-                result = .success(content.block)
-            case .failure(let error):
-                experimentId = nil
-                variantId = nil
-                kind = nil
-                result = .failure(error)
-            }
-
-            self.onDispatch?(event)
-
-            await MainActor.run { [weak self] in
-                guard let self else {
-                    return
-                }
-                if !self.didLoaded {
-                    print("nativebrik.dispatch should be called after nativebrik.overlay did load")
-                    return
-                }
-                switch result {
-                case .success(let block):
-                    switch block {
-                    case .EUIRootBlock(let root):
-                        if kind == .TOOLTIP,
-                           let onTooltip = self.onTooltip,
-                           let experimentId = experimentId {
-                            if let jsonData = try? JSONEncoder().encode(block),
-                               let jsonString = String(data: jsonData, encoding: .utf8) {
-                                onTooltip(jsonString, experimentId, variantId)
-                            }
-                        } else {
-                            let root = ModalRootViewController(
-                                root: root,
-                                experimentId: experimentId,
-                                variantId: variantId,
-                                container: self.container,
-                                modalViewController: self.modalViewController
-                            )
-                            if let currentVC = self.currentVC {
-                                currentVC.removeFromParent()
-                                self.currentVC = nil
-                            }
-                            self.addChild(root)
-                            self.currentVC = root
-                        }
-                    default:
-                        break
-                    }
-                default:
-                    break
-                }
-            }
+            await self.performDispatch(event: event)
         }
-    } // END dispatch
+    }
+
+    @MainActor
+    func performDispatch(event: NubrickEvent) async {
+        // onTooltip is only set in the Flutter SDK. Tooltips are a Flutter-only feature,
+        // so we fetch both popups and tooltips when running in Flutter, and popups only otherwise.
+        let kinds: [ExperimentKind] = self.onTooltip != nil ? [.POPUP, .TOOLTIP] : [.POPUP]
+        let triggerResult = await self.container.fetchTriggerContent(trigger: event.name, kinds: kinds)
+        let experimentId: String?
+        let variantId: String?
+        let kind: ExperimentKind?
+        let result: Result<UIBlock, NubrickError>
+        switch triggerResult {
+        case .success(let content):
+            experimentId = content.experimentId
+            variantId = content.variantId
+            kind = content.kind
+            result = .success(content.block)
+        case .failure(let error):
+            experimentId = nil
+            variantId = nil
+            kind = nil
+            result = .failure(error)
+        }
+
+        self.onDispatch?(event)
+
+        if !self.didLoaded {
+            print("nativebrik.dispatch should be called after nativebrik.overlay did load")
+            return
+        }
+        switch result {
+        case .success(let block):
+            switch block {
+            case .EUIRootBlock(let root):
+                if kind == .TOOLTIP,
+                   let onTooltip = self.onTooltip,
+                   let experimentId = experimentId {
+                    if let jsonData = try? JSONEncoder().encode(block),
+                       let jsonString = String(data: jsonData, encoding: .utf8) {
+                        onTooltip(jsonString, experimentId, variantId)
+                    }
+                } else {
+                    let root = ModalRootViewController(
+                        root: root,
+                        experimentId: experimentId,
+                        variantId: variantId,
+                        container: self.container,
+                        modalViewController: self.modalViewController
+                    )
+                    if let currentVC = self.currentVC {
+                        currentVC.removeFromParent()
+                        self.currentVC = nil
+                    }
+                    self.addChild(root)
+                    self.currentVC = root
+                }
+            default:
+                break
+            }
+        default:
+            break
+        }
+    }
 }

--- a/Sources/Nubrick/_for_bridge.swift
+++ b/Sources/Nubrick/_for_bridge.swift
@@ -54,7 +54,7 @@ public enum NubrickBridge {
         httpRequestInterceptor: NubrickHttpRequestInterceptor? = nil,
         onDispatch: ((_ event: NubrickEvent) -> Void)? = nil,
         trackCrashes: Bool = true,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)? = nil
+        onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)? = nil
     ) {
         NubrickSDK.initializeBridge(
             projectId: projectId,
@@ -69,7 +69,7 @@ public enum NubrickBridge {
     public static func updateCallbacks(
         onEvent: (@Sendable (_ event: ComponentEvent) -> Void)? = nil,
         onDispatch: ((_ event: NubrickEvent) -> Void)? = nil,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)? = nil
+        onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)? = nil
     ) {
         guard let runtime = NubrickSDK.requireRuntime() else { return }
         runtime.updateBridgeCallbacks(onEvent: onEvent, onDispatch: onDispatch, onTooltip: onTooltip)
@@ -101,6 +101,8 @@ public enum NubrickBridge {
 
     public static func renderUIView(
         json: String,
+        experimentId: String? = nil,
+        variantId: String? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
         onNextTooltip: ((_ pageId: String) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
@@ -110,6 +112,8 @@ public enum NubrickBridge {
         }
         return runtime.renderUIView(
             json: json,
+            experimentId: experimentId,
+            variantId: variantId,
             onEvent: onEvent,
             onNextTooltip: onNextTooltip,
             onDismiss: onDismiss

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -158,7 +158,7 @@ final class NubrickCore {
         onEvent: (@Sendable (_ event: ComponentEvent) -> Void)?,
         httpRequestInterceptor: NubrickHttpRequestInterceptor?,
         onDispatch: ((_ event: NubrickEvent) -> Void)?,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+        onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)?
     ) {
         let user = NubrickUser()
         let bridgeCallbackStore = BridgeCallbackStore(onEvent: onEvent)
@@ -203,7 +203,7 @@ final class NubrickCore {
     func updateBridgeCallbacks(
         onEvent: (@Sendable (_ event: ComponentEvent) -> Void)?,
         onDispatch: ((_ event: NubrickEvent) -> Void)?,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+        onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)?
     ) {
         if let onEvent {
             self.bridgeCallbackStore.onEvent = onEvent
@@ -391,6 +391,8 @@ final class NubrickCore {
 
     func renderUIView(
         json: String,
+        experimentId: String? = nil,
+        variantId: String? = nil,
         onEvent: ((_ event: ComponentEvent) -> Void)? = nil,
         onNextTooltip: ((_ pageId: String) -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
@@ -401,6 +403,8 @@ final class NubrickCore {
             let decoded = try decoder.decode(UIRootBlock.self, from: data)
             return NubrickBridgedViewAccessor(rootView: RootView(
                 root: decoded,
+                experimentId: experimentId,
+                variantId: variantId,
                 container: self.makeContainer(),
                 arguments: nil,
                 modalViewController: self.overlayVC.modalViewController,
@@ -456,7 +460,7 @@ public enum NubrickSDK {
         httpRequestInterceptor: NubrickHttpRequestInterceptor?,
         onDispatch: ((_ event: NubrickEvent) -> Void)?,
         trackCrashes: Bool,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+        onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)?
     ) -> Bool {
         guard runtime == nil else {
             nubrickWarn("NubrickSDK.initialize(...) called more than once. Ignoring subsequent call.")
@@ -491,7 +495,7 @@ public enum NubrickSDK {
         httpRequestInterceptor: NubrickHttpRequestInterceptor?,
         onDispatch: ((_ event: NubrickEvent) -> Void)?,
         trackCrashes: Bool,
-        onTooltip: ((_ data: String, _ experimentId: String) -> Void)?
+        onTooltip: ((_ data: String, _ experimentId: String, _ variantId: String?) -> Void)?
     ) -> Bool {
         if runtime != nil {
             nubrickWarn("NubrickBridge.initialize(...) called more than once. Subsequent calls are ignored.")

--- a/Tests/NubrickTests/Component/trigger.swift
+++ b/Tests/NubrickTests/Component/trigger.swift
@@ -81,7 +81,6 @@ private final class TriggerContainerSpy: Container, @unchecked Sendable {
 final class TriggerViewControllerTests: XCTestCase {
     @MainActor
     func testTooltipCallbackIncludesExperimentAndVariantContext() async {
-        let callbackSemaphore = DispatchSemaphore(value: 0)
         var receivedData: String?
         var receivedExperimentId: String?
         var receivedVariantId: String?
@@ -93,20 +92,12 @@ final class TriggerViewControllerTests: XCTestCase {
                 receivedData = data
                 receivedExperimentId = experimentId
                 receivedVariantId = variantId
-                callbackSemaphore.signal()
             }
         )
 
         controller.initialLoad()
-        controller.dispatch(event: NubrickEvent("tooltip-trigger"))
+        await controller.performDispatch(event: NubrickEvent("tooltip-trigger"))
 
-        let waitResult = await Task.detached {
-            callbackSemaphore.wait(timeout: .now() + 1)
-        }.value
-        guard waitResult == .success else {
-            XCTFail("Tooltip callback was not invoked")
-            return
-        }
         guard let receivedData,
               let jsonData = receivedData.data(using: .utf8),
               let block = try? JSONDecoder().decode(UIBlock.self, from: jsonData),

--- a/Tests/NubrickTests/Component/trigger.swift
+++ b/Tests/NubrickTests/Component/trigger.swift
@@ -1,0 +1,121 @@
+import Combine
+import XCTest
+@testable import NubrickLocal
+
+private final class TriggerContainerSpy: Container, @unchecked Sendable {
+    let experimentId: String? = nil
+    let variantId: String? = nil
+
+    @MainActor
+    func handleEvent(_ it: UIBlockAction) {}
+
+    @MainActor
+    func makeContainer() -> Container { self }
+
+    @MainActor
+    func makeContainer(experimentId: String?, variantId: String?) -> Container { self }
+
+    @MainActor
+    func createVariableForTemplate(
+        data: Any?,
+        properties: [Property]?,
+        arguments: NubrickArguments?
+    ) -> Variable? { nil }
+
+    @MainActor
+    func getFormValue(key: String) -> Any? { nil }
+
+    @MainActor
+    func getFormValues() -> [String: Any] { [:] }
+
+    @MainActor
+    func setFormValue(key: String, value: Any) {}
+
+    @MainActor
+    func formDataPublisher() -> AnyPublisher<[String: Any], Never> {
+        Just([:]).eraseToAnyPublisher()
+    }
+
+    @MainActor
+    func userDataPublisher() -> AnyPublisher<[String: Any], Never> {
+        Just([:]).eraseToAnyPublisher()
+    }
+
+    func sendHttpRequest(
+        req: ApiHttpRequest,
+        assertion: ApiHttpResponseAssertion?,
+        variable: Variable?
+    ) async -> Result<JSONData, NubrickError> {
+        .failure(.notFound)
+    }
+
+    func fetchEmbedding(
+        experimentId: String,
+        componentId: String?
+    ) async -> Result<FetchedEmbedding, NubrickError> {
+        .failure(.notFound)
+    }
+
+    func fetchTriggerContent(
+        trigger: String,
+        kinds: [ExperimentKind]
+    ) async -> Result<FetchedTriggerContent, NubrickError> {
+        guard trigger == "tooltip-trigger" else {
+            return .failure(.notFound)
+        }
+        return .success(FetchedTriggerContent(
+            experimentId: "tooltip-experiment-id",
+            variantId: "tooltip-variant-id",
+            kind: .TOOLTIP,
+            block: .EUIRootBlock(UIRootBlock(id: "tooltip-root", data: nil))
+        ))
+    }
+
+    func fetchRemoteConfig(
+        experimentId: String
+    ) async -> Result<(String, ExperimentVariant), NubrickError> {
+        .failure(.notFound)
+    }
+}
+
+final class TriggerViewControllerTests: XCTestCase {
+    @MainActor
+    func testTooltipCallbackIncludesExperimentAndVariantContext() async {
+        let callbackSemaphore = DispatchSemaphore(value: 0)
+        var receivedData: String?
+        var receivedExperimentId: String?
+        var receivedVariantId: String?
+        let controller = TriggerViewController(
+            user: NubrickUser(),
+            container: TriggerContainerSpy(),
+            modalViewController: nil,
+            onTooltip: { data, experimentId, variantId in
+                receivedData = data
+                receivedExperimentId = experimentId
+                receivedVariantId = variantId
+                callbackSemaphore.signal()
+            }
+        )
+
+        controller.initialLoad()
+        controller.dispatch(event: NubrickEvent("tooltip-trigger"))
+
+        let waitResult = await Task.detached {
+            callbackSemaphore.wait(timeout: .now() + 1)
+        }.value
+        guard waitResult == .success else {
+            XCTFail("Tooltip callback was not invoked")
+            return
+        }
+        guard let receivedData,
+              let jsonData = receivedData.data(using: .utf8),
+              let block = try? JSONDecoder().decode(UIBlock.self, from: jsonData),
+              case .EUIRootBlock(let root) = block else {
+            XCTFail("Expected an encoded root block")
+            return
+        }
+        XCTAssertEqual(root.id, "tooltip-root")
+        XCTAssertEqual(receivedExperimentId, "tooltip-experiment-id")
+        XCTAssertEqual(receivedVariantId, "tooltip-variant-id")
+    }
+}

--- a/Tests/NubrickTests/Data/repository.swift
+++ b/Tests/NubrickTests/Data/repository.swift
@@ -197,4 +197,46 @@ final class ContainerTests: XCTestCase {
         XCTAssertEqual(responseJSON, ["answer": "yes"])
         XCTAssertEqual(handledAction?.eventName, "survey-submitted")
     }
+
+    func testRootViewAppliesExperimentContextToSurveyResponses() async throws {
+        let db = try XCTUnwrap(createNativebrikCoreDataHelper(), "Could not init DB")
+        let user = NubrickUser()
+        let config = Config(projectId: PROJECT_ID_FOR_TEST)
+        let trackRepository = SurveyResponseTrackRepositorySpy()
+        let container = ContainerImpl(
+            config: config,
+            user: user,
+            actionHandler: { _, _ in },
+            experimentRepository: ExperimentRepositoryImpl(config: config),
+            componentRepository: ComponentRepositoryImpl(config: config),
+            trackRepository: trackRepository,
+            databaseRepository: DatabaseRepositoryImpl(persistentContainer: db),
+            httpRequestRepository: HttpRequestRepositoryImpl()
+        )
+        let rootView = RootView(
+            root: nil,
+            experimentId: "tooltip-experiment-id",
+            variantId: "tooltip-variant-id",
+            container: container,
+            modalViewController: nil,
+            onEvent: nil
+        )
+        let action = UIBlockAction(
+            eventName: "survey-submitted",
+            name: nil,
+            destinationPageId: nil,
+            deepLink: nil,
+            payload: nil,
+            requiredFields: nil,
+            httpRequest: nil,
+            httpResponseAssertion: nil,
+            submitSurveyResponse: true
+        )
+
+        rootView.dispatchAction(action)
+
+        let response = await trackRepository.nextResponse()
+        XCTAssertEqual(response.experimentId, "tooltip-experiment-id")
+        XCTAssertEqual(response.variantId, "tooltip-variant-id")
+    }
 }


### PR DESCRIPTION
## Summary

- include the selected variant ID in Flutter tooltip callbacks
- pass tooltip experiment and variant context into rendered UIKit views so survey responses retain attribution
- add regression coverage for tooltip callback context and survey response context propagation

## Testing

- `xcodebuild -project Nubrick/Nubrick.xcodeproj -scheme Nubrick -destination 'generic/platform=iOS Simulator' build`
- `TriggerViewControllerTests.testTooltipCallbackIncludesExperimentAndVariantContext`
- `ContainerTests.testRootViewAppliesExperimentContextToSurveyResponses`
