### PR TITLE
Fix missing corner radius when borderRadius is omitted

### DIFF
--- a/Sources/Nubrick/Util/utils.swift
+++ b/Sources/Nubrick/Util/utils.swift
@@ -428,9 +428,13 @@ func configureBorder(view: UIView, frame: FrameData?) {
         if let bc = frame?.borderColor {
             view.layer.borderColor = parseColorToCGColor(bc)
         }
+        // Prefer borderRadius; if omitted, use the shared per-corner value
+        // (all four corners are equal when isSingleRadius is true).
         view.layer.cornerRadius = CGFloat(
             normalizeSingleRadius(
-                radius: CGFloat(frame?.borderRadius ?? 0), width: width, height: height))
+                radius: CGFloat(frame?.borderRadius ?? frame?.borderTopLeftRadius ?? 0),
+                width: width,
+                height: height))
         return
     }
 


### PR DESCRIPTION
## Summary
- When all four per-corner border radii are equal and `borderRadius` is omitted, the single-radius path previously defaulted to `0` and ignored the corner fields.
- Fall back to the shared per-corner value (`borderTopLeftRadius`) so equal corner radii still apply.

## Test plan
- [ ] Apply a frame with `borderTopLeftRadius`/`borderTopRightRadius`/`borderBottomRightRadius`/`borderBottomLeftRadius` all set to the same value and omit `borderRadius` — corners should round
- [ ] Apply only `borderRadius` (no per-corner fields) — still works as before
- [ ] Apply unequal per-corner radii — still uses the per-corner path
- [ ] Omit all radius fields — remains square (radius 0)


Made with [Cursor](https://cursor.com)