### PR TITLE
Fix modal safe area layout

### DIFF
--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -307,8 +307,7 @@ final class PageView: UIView {
                         actionHandler: self.actionHandler,
                         layoutInvalidationRoot: self
                     )
-                ),
-                respectSafeArea: self.page?.data?.modalRespectSafeArea
+                )
             )
             self.addSubview(self.view)
 
@@ -323,7 +322,24 @@ final class PageView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         self.updateModalYogaHeight()
+        self.updateModalSafeAreaPadding()
         self.yoga.applyLayout(preservingOrigin: true)
+    }
+
+    override func safeAreaInsetsDidChange() {
+        super.safeAreaInsetsDidChange()
+        setNeedsLayout()
+    }
+
+    private func updateModalSafeAreaPadding() {
+        let shouldRespectSafeArea =
+            self.page?.data?.kind == .MODAL
+            && self.page?.data?.modalRespectSafeArea == true
+        let insets = shouldRespectSafeArea ? safeAreaInsets : .zero
+
+        // Keep the page background full-size while Yoga lays out its rendered
+        // content inside the modal's safe content box.
+        (self.view as? UIViewBlock)?.setSafeAreaInsets(insets)
     }
 
     private func updateModalYogaHeight() {

--- a/Sources/Nubrick/Component/renderer/block.swift
+++ b/Sources/Nubrick/Component/renderer/block.swift
@@ -19,14 +19,14 @@ func childrenToUIViews(data: [UIBlock]?, context: UIBlockContext) -> [UIView] {
 }
 
 @MainActor
-func uiblockToUIView(data: UIBlock, context: UIBlockContext, respectSafeArea: Bool? = false) -> UIView {
+func uiblockToUIView(data: UIBlock, context: UIBlockContext) -> UIView {
     switch data {
     case .EUIFlexContainerBlock(let block):
         switch block.data?.overflow {
         case .SCROLL, .HIDDEN:
-            return FlexOverflowView(block: block, context: context, respectSafeArea: respectSafeArea ?? false)
+            return FlexOverflowView(block: block, context: context)
         default:
-            return FlexView(block: block, context: context, respectSafeArea: respectSafeArea)
+            return FlexView(block: block, context: context)
         }
     case .EUICollectionBlock(let block):
         return CollectionView(block: block, context: context)
@@ -50,11 +50,12 @@ func uiblockToUIView(data: UIBlock, context: UIBlockContext, respectSafeArea: Bo
 }
 
 class UIViewBlock: UIView {
-    private let root: UIView = UIView()
+    private let renderedView: UIView
 
-    init(data: UIBlock, context: UIBlockContext, respectSafeArea: Bool? = false) {
+    init(data: UIBlock, context: UIBlockContext) {
+        let view = uiblockToUIView(data: data, context: context)
+        self.renderedView = view
         super.init(frame: .zero)
-        let view = uiblockToUIView(data: data, context: context, respectSafeArea: respectSafeArea)
 
         self.configureLayout { (layout) in
             layout.isEnabled = true
@@ -70,7 +71,19 @@ class UIViewBlock: UIView {
         self.addSubview(view)
     }
 
+    func setSafeAreaInsets(_ insets: UIEdgeInsets) {
+        switch self.renderedView {
+        case let flexView as FlexView:
+            flexView.setSafeAreaInsets(insets)
+        case let overflowView as FlexOverflowView:
+            overflowView.setSafeAreaInsets(insets)
+        default:
+            break
+        }
+    }
+
     required init?(coder aDecoder: NSCoder) {
+        self.renderedView = UIView()
         super.init(coder: aDecoder)
     }
 

--- a/Sources/Nubrick/Component/renderer/flex.swift
+++ b/Sources/Nubrick/Component/renderer/flex.swift
@@ -14,8 +14,6 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
     private var block: UIFlexContainerBlock = UIFlexContainerBlock()
     private var context: UIBlockContext?
     private var isOverflowView = false
-    private var respectSafeArea = false
-    private var hasActivatedConstraints = false
     var cancellables = Set<AnyCancellable>()
     var backgroundImageLoadTask: Task<Void, Never>?
 
@@ -23,11 +21,10 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
         super.init(coder: aDecoder)
     }
 
-    init(block: UIFlexContainerBlock, context: UIBlockContext, respectSafeArea: Bool? = false) {
+    init(block: UIFlexContainerBlock, context: UIBlockContext) {
         super.init(frame: .zero)
         self.block = block
         self.context = context
-        self.respectSafeArea = respectSafeArea ?? false
         initialize(block: block, context: context, childFlexShrink: nil)
     }
 
@@ -104,27 +101,31 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
         self.backgroundImageLoadTask?.cancel()
     }
 
+    func setSafeAreaInsets(_ insets: UIEdgeInsets) {
+        let frame = self.block.data?.frame
+        self.yoga.paddingTop = YGValue(
+            value: Float(CGFloat(frame?.paddingTop ?? 0) + insets.top),
+            unit: .point
+        )
+        self.yoga.paddingLeft = YGValue(
+            value: Float(CGFloat(frame?.paddingLeft ?? 0) + insets.left),
+            unit: .point
+        )
+        self.yoga.paddingBottom = YGValue(
+            value: Float(CGFloat(frame?.paddingBottom ?? 0) + insets.bottom),
+            unit: .point
+        )
+        self.yoga.paddingRight = YGValue(
+            value: Float(CGFloat(frame?.paddingRight ?? 0) + insets.right),
+            unit: .point
+        )
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         if !isOverflowView {
             configureBorder(view: self, frame: self.block.data?.frame)
         }
-    }
-    
-    override func didMoveToSuperview() {
-        super.didMoveToSuperview()
-        if !self.respectSafeArea { return }
-        guard let superview = superview, !hasActivatedConstraints else { return }
-
-        translatesAutoresizingMaskIntoConstraints = false
-        topAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.topAnchor).isActive = true
-        hasActivatedConstraints = true
-    }
-
-    override func willMove(toSuperview newSuperview: UIView?) {
-        super.willMove(toSuperview: newSuperview)
-        if !self.respectSafeArea { return }
-        if newSuperview == nil { hasActivatedConstraints = false }
     }
 
 }
@@ -142,12 +143,12 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
         super.init(coder: aDecoder)
     }
 
-    init(block: UIFlexContainerBlock, context: UIBlockContext, respectSafeArea: Bool) {
+    init(block: UIFlexContainerBlock, context: UIBlockContext) {
         super.init(frame: .zero)
         self.block = block
         self.context = context
 
-        self.contentInsetAdjustmentBehavior = respectSafeArea ? .always : .never
+        self.contentInsetAdjustmentBehavior = .never
 
         let direction = parseDirection(block.data?.direction)
         let overflow = parseOverflow(block.data?.overflow)
@@ -207,6 +208,15 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
         self.backgroundImageLoadTask?.cancel()
     }
 
+    func setSafeAreaInsets(_ insets: UIEdgeInsets) {
+        guard self.contentInset != insets else {
+            return
+        }
+        self.contentInset = insets
+        self.verticalScrollIndicatorInsets = insets
+        self.horizontalScrollIndicatorInsets = insets
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
 
@@ -215,10 +225,18 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
         // Set min size so inner FlexView fills at least the visible area
         let direction = parseDirection(self.block.data?.direction)
         if direction == .column {
-            self.flexView.yoga.minHeight = YGValue(value: Float(self.bounds.height), unit: .point)
+            let visibleHeight = max(
+                0,
+                self.bounds.height - self.contentInset.top - self.contentInset.bottom
+            )
+            self.flexView.yoga.minHeight = YGValue(value: Float(visibleHeight), unit: .point)
             self.flexView.yoga.applyLayout(preservingOrigin: true, dimensionFlexibility: .flexibleHeight)
         } else {
-            self.flexView.yoga.minWidth = YGValue(value: Float(self.bounds.width), unit: .point)
+            let visibleWidth = max(
+                0,
+                self.bounds.width - self.contentInset.left - self.contentInset.right
+            )
+            self.flexView.yoga.minWidth = YGValue(value: Float(visibleWidth), unit: .point)
             self.flexView.yoga.applyLayout(preservingOrigin: true, dimensionFlexibility: .flexibleWidth)
         }
 


### PR DESCRIPTION
## Summary
- apply modal safe-area insets to the rendered content while retaining a full-size page background
- account for safe-area insets in scrollable flex content sizing
- update safe-area layout when the host insets change

## Validation
- xcodebuild -workspace Nubrick.xcworkspace -scheme "Nubrick (Nubrick project)" -destination "generic/platform=iOS Simulator" build