### PR TITLE
Fix modal sheet backgrounds during drag

### DIFF
--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -311,10 +311,11 @@ final class PageView: UIView {
             )
             self.addSubview(self.view)
 
-            // if it's transparent and it's modal, use systemBgColor as the background.
-            // i think this should be refactored someday.
-            if self.view.backgroundColor == nil && self.page?.data?.kind == .MODAL {
-                self.view.backgroundColor = .systemBackground
+            if self.page?.data?.kind == .MODAL {
+                // An explicit page color must cover the sheet while it stretches.
+                // Keep an uncoloured page clear so its modal retains UIKit's native
+                // Liquid Glass surface instead of receiving a white fallback.
+                self.backgroundColor = self.view.backgroundColor
             }
         }
     }

--- a/Sources/Nubrick/Component/renderer/block.swift
+++ b/Sources/Nubrick/Component/renderer/block.swift
@@ -57,6 +57,11 @@ class UIViewBlock: UIView {
         self.renderedView = view
         super.init(frame: .zero)
 
+        if case let .EUIFlexContainerBlock(block) = data,
+           let background = block.data?.frame?.background {
+            self.backgroundColor = parseColor(background)
+        }
+
         self.configureLayout { (layout) in
             layout.isEnabled = true
             layout.display = .flex

--- a/Sources/Nubrick/Component/renderer/modal-component.swift
+++ b/Sources/Nubrick/Component/renderer/modal-component.swift
@@ -72,6 +72,7 @@ class ModalComponentViewController: UIViewController {
             if let sheet = modal.sheetPresentationController {
                 sheet.detents = parseModalScreenSize(modalScreenSize)
             }
+            modal.updateSheetBackground(for: pageController)
             self.currentModal = modal
             self.presentToTop(modal)
         }

--- a/Sources/Nubrick/Component/renderer/navigation.swift
+++ b/Sources/Nubrick/Component/renderer/navigation.swift
@@ -41,7 +41,6 @@ class NavigationViewControlller: UINavigationController {
             layout.alignItems = .center
             layout.justifyContent = .center
         }
-        self.view.backgroundColor = .systemBackground
         self.interactivePopGestureRecognizer?.delegate = self
         self.interactivePopGestureRecognizer?.isEnabled = true
     }
@@ -49,6 +48,10 @@ class NavigationViewControlller: UINavigationController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         self.parent?.viewDidLayoutSubviews()
+    }
+
+    func updateSheetBackground(for viewController: UIViewController) {
+        self.view.backgroundColor = viewController.view.backgroundColor
     }
 
     override func pushViewController(_ viewController: UIViewController, animated: Bool) {
@@ -81,10 +84,17 @@ class NavigationViewControlller: UINavigationController {
 
 extension NavigationViewControlller: UINavigationControllerDelegate {
 
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        guard let swipeNavigationController = navigationController as? NavigationViewControlller else { return }
+
+        swipeNavigationController.updateSheetBackground(for: viewController)
+    }
+
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         guard let swipeNavigationController = navigationController as? NavigationViewControlller else { return }
 
         swipeNavigationController.duringPushAnimation = false
+        swipeNavigationController.updateSheetBackground(for: viewController)
     }
 
 }


### PR DESCRIPTION
## Summary
- Propagate a modal page's flex background to its sheet navigation container.
- Preserve the native sheet surface for pages without an explicit background.
- Keep the sheet background synchronized across modal navigation transitions.
