### PR TITLE
Fix image aspect ratio when dimensions are omitted

### DIFF
--- a/Sources/Nubrick/Component/renderer/image.swift
+++ b/Sources/Nubrick/Component/renderer/image.swift
@@ -29,8 +29,15 @@ class ImageView: AnimatedUIView {
         self.configureLayout { layout in
             layout.isEnabled = true
 
-            configurePadding(layout: layout, frame: block.data?.frame)
+            // Image padding is not supported by the editor so we dont apply padding
             configureSize(layout: layout, frame: block.data?.frame, parentDirection: context.getParentDireciton())
+
+            // image URLs include dimensions for their blurhash
+            // fallback. Use them until the full image provides exact dimensions.
+            if hasMissingImageDimension(block.data?.frame),
+               let aspectRatio = parseImageFallbackAspectRatio(block.data?.src ?? "") {
+                layout.aspectRatio = aspectRatio
+            }
         }
 
         self.image.configureLayout { layout in
@@ -100,6 +107,8 @@ class ImageView: AnimatedUIView {
     }
 
     private func applyImageSource(_ src: String) {
+        self.configureImageAspectRatio(src)
+
         let fallbackSetting = parseImageFallbackToBlurhash(src)
         self.image.image = fallbackSetting.blurhash == "" ? UIImage() : UIImage(
             blurHash: fallbackSetting.blurhash,
@@ -109,9 +118,36 @@ class ImageView: AnimatedUIView {
         self.imageLoadTask = loadAsyncImage(
             url: src,
             image: self.image,
-            layoutRoot: self.context?.getLayoutInvalidationRoot()
+            layoutRoot: self.context?.getLayoutInvalidationRoot(),
+            onImageLoaded: { [weak self] image in
+                self?.configureImageAspectRatio(imageAspectRatio(
+                    width: image.size.width,
+                    height: image.size.height
+                ))
+            }
         )
     }
+
+    private func configureImageAspectRatio(_ src: String) {
+        self.configureImageAspectRatio(parseImageFallbackAspectRatio(src))
+    }
+
+    private func configureImageAspectRatio(_ aspectRatio: CGFloat?) {
+        guard hasMissingImageDimension(self.block.data?.frame) else {
+            return
+        }
+
+        self.yoga.aspectRatio = aspectRatio ?? .nan
+        self.context?.getLayoutInvalidationRoot()?.setNeedsLayout()
+    }
+}
+
+private func hasMissingImageDimension(_ frame: FrameData?) -> Bool {
+    hasMissingImageDimension(width: frame?.width, height: frame?.height)
+}
+
+func hasMissingImageDimension(width: Int?, height: Int?) -> Bool {
+    width == nil || height == nil
 }
 
 @MainActor
@@ -176,7 +212,12 @@ func loadAsyncImageToBackgroundSrc(url: String, view: UIView) -> Task<Void, Neve
 }
 
 @MainActor
-func loadAsyncImage(url: String, image: UIImageView, layoutRoot: UIView?) -> Task<Void, Never>? {
+func loadAsyncImage(
+    url: String,
+    image: UIImageView,
+    layoutRoot: UIView?,
+    onImageLoaded: ((UIImage) -> Void)? = nil
+) -> Task<Void, Never>? {
     guard let requestUrl = URL(string: url) else {
         return nil
     }
@@ -190,25 +231,25 @@ func loadAsyncImage(url: String, image: UIImageView, layoutRoot: UIView?) -> Tas
                 guard !Task.isCancelled else {
                     return
                 }
+                let loadedImage: UIImage?
                 if isGif(response) {
-                    UIView.transition(
-                        with: image,
-                        duration: 0.2,
-                        options: .transitionCrossDissolve,
-                        animations: {
-                            image.image = UIImage.gifImageWithData(data)
-                        },
-                        completion: nil)
+                    loadedImage = UIImage.gifImageWithData(data)
                 } else {
-                    UIView.transition(
-                        with: image,
-                        duration: 0.2,
-                        options: .transitionCrossDissolve,
-                        animations: {
-                            image.image = UIImage(data: data)
-                        },
-                        completion: nil)
+                    loadedImage = UIImage(data: data)
                 }
+                guard let loadedImage else {
+                    return
+                }
+
+                UIView.transition(
+                    with: image,
+                    duration: 0.2,
+                    options: .transitionCrossDissolve,
+                    animations: {
+                        image.image = loadedImage
+                    },
+                    completion: nil)
+                onImageLoaded?(loadedImage)
                 if let layoutRoot {
                     invalidateYogaLayout(from: image, layoutRoot: layoutRoot)
                 }

--- a/Sources/Nubrick/Util/utils.swift
+++ b/Sources/Nubrick/Util/utils.swift
@@ -292,6 +292,19 @@ struct ImageFallback {
     let width: Int
     let height: Int
 }
+
+func imageAspectRatio(width: CGFloat, height: CGFloat) -> CGFloat? {
+    guard width > 0, height > 0 else {
+        return nil
+    }
+    return CGFloat(width) / CGFloat(height)
+}
+
+func parseImageFallbackAspectRatio(_ src: String) -> CGFloat? {
+    let fallback = parseImageFallbackToBlurhash(src)
+    return imageAspectRatio(width: CGFloat(fallback.width), height: CGFloat(fallback.height))
+}
+
 func parseImageFallbackToBlurhash(_ src: String) -> ImageFallback {
     guard let url = URL(string: src) else {
         return ImageFallback(blurhash: "", width: 0, height: 0)

--- a/Tests/NubrickTests/Util/utils.swift
+++ b/Tests/NubrickTests/Util/utils.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import NubrickLocal
+
+final class ImageUtilTests: XCTestCase {
+    func testParseImageFallbackAspectRatioUsesBlurhashMetadata() {
+        let src = "https://cdn.nativebrik.com/image?b=blurhash&h=23&w=44"
+
+        XCTAssertEqual(parseImageFallbackAspectRatio(src), 44.0 / 23.0)
+    }
+
+    func testParseImageFallbackAspectRatioRequiresBlurhashAndPositiveDimensions() {
+        XCTAssertNil(parseImageFallbackAspectRatio("https://cdn.nativebrik.com/image?b=blurhash&h=0&w=44"))
+        XCTAssertNil(parseImageFallbackAspectRatio("https://cdn.nativebrik.com/image?h=23&w=44"))
+    }
+
+    func testImageAspectRatioRequiresPositiveDimensions() {
+        XCTAssertEqual(imageAspectRatio(width: 1080, height: 566), 1080.0 / 566.0)
+        XCTAssertNil(imageAspectRatio(width: 0, height: 566))
+    }
+
+    func testImageDimensionDerivationRequiresAnOmittedDimension() {
+        XCTAssertTrue(hasMissingImageDimension(width: 200, height: nil))
+        XCTAssertTrue(hasMissingImageDimension(width: nil, height: 200))
+        XCTAssertFalse(hasMissingImageDimension(width: 200, height: 100))
+    }
+}


### PR DESCRIPTION
## Summary

- derive image aspect ratios from blurhash metadata while images load
- update the ratio from the downloaded image dimensions
- cover image aspect-ratio parsing and missing-dimension behavior

Closes plaidev/nativebrik#2429