### PR TITLE
Restore default modal background before Liquid Glass

### DIFF
--- a/Sources/Nubrick/Component/page.swift
+++ b/Sources/Nubrick/Component/page.swift
@@ -313,9 +313,14 @@ final class PageView: UIView {
 
             if self.page?.data?.kind == .MODAL {
                 // An explicit page color must cover the sheet while it stretches.
-                // Keep an uncoloured page clear so its modal retains UIKit's native
-                // Liquid Glass surface instead of receiving a white fallback.
-                self.backgroundColor = self.view.backgroundColor
+                // On Liquid Glass, keep an uncoloured page clear so UIKit provides
+                // its native sheet surface. Earlier iOS versions need the system
+                // background; otherwise the default over-full-screen modal is clear.
+                if #available(iOS 26.0, *) {
+                    self.backgroundColor = self.view.backgroundColor
+                } else {
+                    self.backgroundColor = self.view.backgroundColor ?? .systemBackground
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- restore the system modal background for uncoloured modals on iOS versions before Liquid Glass
- preserve UIKit's native Liquid Glass surface on iOS 26 and later

## Validation
- xcodebuild -project Nubrick/Nubrick.xcodeproj -scheme Nubrick -destination 'generic/platform=iOS Simulator' build