### PR TITLE
Refine action tap feedback

### DIFF
--- a/Sources/Nubrick/Component/action-listener.swift
+++ b/Sources/Nubrick/Component/action-listener.swift
@@ -80,7 +80,7 @@ class AnimatedUIView: UIView {
         }
 
         onTouchBegan = { [weak self] in
-            if uiBlockAction != nil && context.hasParent() {
+            if hasTapFeedback(uiBlockAction) && context.hasParent() {
                 UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut) {
                     self?.transform = CGAffineTransform(scaleX: 0.984, y: 0.984)
                 }
@@ -89,7 +89,7 @@ class AnimatedUIView: UIView {
             }
         }
         onTouchEnded = { [weak self] in
-            if uiBlockAction != nil && context.hasParent() {
+            if hasTapFeedback(uiBlockAction) && context.hasParent() {
                 UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut) {
                     self?.transform = CGAffineTransform(scaleX: 1, y: 1)
                 }
@@ -98,7 +98,7 @@ class AnimatedUIView: UIView {
             }
         }
         onTouchCanceled = { [weak self] in
-            if uiBlockAction != nil && context.hasParent() {
+            if hasTapFeedback(uiBlockAction) && context.hasParent() {
                 UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut) {
                     self?.transform = CGAffineTransform(scaleX: 1, y: 1)
                 }
@@ -107,6 +107,14 @@ class AnimatedUIView: UIView {
             }
         }
     }
+}
+
+func hasTapFeedback(_ action: UIBlockAction?) -> Bool {
+    guard let action else { return false }
+    return action.destinationPageId != nil
+        || action.deepLink != nil
+        || action.httpRequest != nil
+        || action.submitSurveyResponse == true
 }
 
 func isDisabled(requiredFields: [String], values: [String: Any]) -> Bool {

--- a/Tests/NubrickTests/Component/action-listener.swift
+++ b/Tests/NubrickTests/Component/action-listener.swift
@@ -3,6 +3,27 @@ import XCTest
 @testable import NubrickLocal
 
 final class ActionListenerTests: XCTestCase {
+    func testHTTPActionHasTapFeedback() {
+        let action = UIBlockAction(
+            eventName: nil,
+            name: nil,
+            destinationPageId: nil,
+            deepLink: nil,
+            payload: nil,
+            requiredFields: nil,
+            httpRequest: ApiHttpRequest(
+                url: "https://example.com",
+                method: .POST,
+                headers: nil,
+                body: nil
+            ),
+            httpResponseAssertion: nil,
+            submitSurveyResponse: nil
+        )
+
+        XCTAssertTrue(hasTapFeedback(action))
+    }
+
     func testRequiredFieldsTreatMissingAndEmptyValuesAsDisabled() {
         XCTAssertTrue(isDisabled(requiredFields: ["answer"], values: [:]))
         XCTAssertTrue(isDisabled(requiredFields: ["answer"], values: ["answer": ""]))


### PR DESCRIPTION
## Summary
- apply tap feedback only to actions with a user-visible effect
- forward event-only child actions to the enclosing actionable view
- cover HTTP request actions with a unit test

## Testing
- `swift test --filter ActionListenerTests` (fails in this environment because UIKit headers are unavailable)