### PR TITLE
Fix flex overflow sizing

### DIFF
--- a/Sources/Nubrick/Component/renderer/collection.swift
+++ b/Sources/Nubrick/Component/renderer/collection.swift
@@ -302,7 +302,7 @@ class CollectionView: AnimatedUIView, UICollectionViewDataSource, UICollectionVi
                                 return _replaceVariableData(base: variable, data: childData)
                             },
                             parentView: self,
-                            parentDirection: self.block?.data?.direction,
+                            parentDirection: resolvedFlexDirection(self.block?.data?.direction),
                             layoutInvalidationRoot: cell
                         )
                     )
@@ -317,7 +317,7 @@ class CollectionView: AnimatedUIView, UICollectionViewDataSource, UICollectionVi
                     context: self.context.instanciateFrom(
                         UIBlockContextChildInit(
                             parentView: self,
-                            parentDirection: self.block?.data?.direction,
+                            parentDirection: resolvedFlexDirection(self.block?.data?.direction),
                             layoutInvalidationRoot: cell
                         )
                     )

--- a/Sources/Nubrick/Component/renderer/flex.swift
+++ b/Sources/Nubrick/Component/renderer/flex.swift
@@ -10,6 +10,15 @@ import Foundation
 import UIKit
 internal import YogaKit
 
+private func minimumSizePreservingUnit(_ size: YGValue) -> YGValue {
+    switch size.unit {
+    case .point, .percent:
+        return size
+    default:
+        return YGValueUndefined
+    }
+}
+
 class FlexView: AnimatedUIView, BackgroundImageObserver {
     private var block: UIFlexContainerBlock = UIFlexContainerBlock()
     private var context: UIBlockContext?
@@ -36,7 +45,8 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
     }
 
     func initialize(block: UIFlexContainerBlock, context: UIBlockContext, childFlexShrink: Int?) {
-        let direction = parseDirection(block.data?.direction)
+        let resolvedDirection = resolvedFlexDirection(block.data?.direction)
+        let direction = parseDirection(resolvedDirection)
         self.isOverflowView =
             block.data?.overflow == Overflow.SCROLL || block.data?.overflow == Overflow.HIDDEN
         self.configureLayout { layout in
@@ -60,7 +70,7 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
                     context: context.instanciateFrom(
                         UIBlockContextChildInit(
                             parentView: self,
-                            parentDirection: block.data?.direction
+                            parentDirection: resolvedDirection
                         )
                     ))
             } ?? []
@@ -80,8 +90,8 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
                 if let childFlexShrink = childFlexShrink {
                     layout.isEnabled = true
                     layout.flexShrink = CGFloat(childFlexShrink)
-                    layout.minWidth = .init(value: layout.width.value, unit: .point)
-                    layout.minHeight = .init(value: layout.height.value, unit: .point)
+                    layout.minWidth = minimumSizePreservingUnit(layout.width)
+                    layout.minHeight = minimumSizePreservingUnit(layout.height)
                 }
             }
 
@@ -150,7 +160,8 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
 
         self.contentInsetAdjustmentBehavior = .never
 
-        let direction = parseDirection(block.data?.direction)
+        let resolvedDirection = resolvedFlexDirection(block.data?.direction)
+        let direction = parseDirection(resolvedDirection)
         let overflow = parseOverflow(block.data?.overflow)
         self.configureLayout { layout in
             layout.isEnabled = true
@@ -175,17 +186,15 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
         
         // Create child context with FlexOverflowView's direction as the parent direction
         let childContext = context.instanciateFrom(
-            UIBlockContextChildInit(parentDirection: block.data?.direction)
+            UIBlockContextChildInit(parentDirection: resolvedDirection)
         )
         let flexView = FlexView(block: block, context: childContext, childFlexShrink: 0)  // set child's size to shrink 0.
         flexView.configureLayout { layout in
             if direction == .column {
-                layout.width = .init(value: 100, unit: .percent)
                 layout.maxHeight = YGValueUndefined
                 layout.minHeight = YGValueUndefined
                 layout.height = YGValueAuto
             } else {
-                layout.height = .init(value: 100, unit: .percent)
                 layout.width = YGValueAuto
                 layout.maxWidth = YGValueUndefined
                 layout.minWidth = YGValueUndefined

--- a/Sources/Nubrick/Util/utils.swift
+++ b/Sources/Nubrick/Util/utils.swift
@@ -48,8 +48,12 @@ func parseIntForFlex(_ data: Int?) -> YGValue? {
     }
 }
 
+func resolvedFlexDirection(_ data: FlexDirection?) -> FlexDirection {
+    data == .COLUMN ? .COLUMN : .ROW
+}
+
 func parseDirection(_ data: FlexDirection?) -> YGFlexDirection {
-    switch data {
+    switch resolvedFlexDirection(data) {
     case .COLUMN:
         return .column
     default:

--- a/Tests/NubrickTests/Component/flex.swift
+++ b/Tests/NubrickTests/Component/flex.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import NubrickLocal
+import YogaKit
+
+final class FlexOverflowViewTests: XCTestCase {
+    @MainActor
+    func testDefaultRowMakesZeroWidthChildGrow() throws {
+        let root = FlexView(
+            block: try makeDefaultRowBlock(),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+
+        let child = try XCTUnwrap(root.subviews.first)
+        XCTAssertTrue(child.yoga.width.value.isNaN)
+        XCTAssertEqual(child.yoga.flexGrow, 1)
+        XCTAssertEqual(child.yoga.flexBasis.value, 0)
+    }
+
+    @MainActor
+    func testHorizontalScrollWithHugHeightMeasuresContentHeight() throws {
+        let view = FlexOverflowView(
+            block: try makeScrollBlock(direction: "ROW", width: 100, height: nil),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+
+        let content = try XCTUnwrap(view.subviews.first)
+        XCTAssertTrue(content.yoga.height.value.isNaN)
+    }
+
+    @MainActor
+    func testHorizontalScrollWithFillHeightFillsViewportHeight() throws {
+        let view = FlexOverflowView(
+            block: try makeScrollBlock(direction: "ROW", width: 100, height: 0),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+
+        let content = try XCTUnwrap(view.subviews.first)
+        XCTAssertEqual(content.yoga.height.value, 100)
+    }
+
+    @MainActor
+    func testVerticalScrollWithHugWidthMeasuresContentWidth() throws {
+        let view = FlexOverflowView(
+            block: try makeScrollBlock(direction: "COLUMN", width: nil, height: 100),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+
+        let content = try XCTUnwrap(view.subviews.first)
+        XCTAssertTrue(content.yoga.width.value.isNaN)
+    }
+
+    @MainActor
+    func testVerticalScrollWithFillWidthFillsViewportWidth() throws {
+        let view = FlexOverflowView(
+            block: try makeScrollBlock(direction: "COLUMN", width: 0, height: 100),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+
+        let content = try XCTUnwrap(view.subviews.first)
+        XCTAssertEqual(content.yoga.width.value, 100)
+    }
+
+    @MainActor
+    func testScrollContentPreservesPercentageMinimums() throws {
+        let view = FlexOverflowView(
+            block: try makeScrollBlock(
+                direction: "COLUMN", width: 0, height: 100, childWidth: 0
+            ),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+
+        let content = try XCTUnwrap(view.subviews.first)
+        let child = try XCTUnwrap(content.subviews.first)
+        XCTAssertEqual(child.yoga.minWidth.unit, .percent)
+    }
+
+    private func makeScrollBlock(
+        direction: String,
+        width: Int?,
+        height: Int?,
+        childWidth: Int? = nil
+    ) throws -> UIFlexContainerBlock {
+        let frame = [
+            width.map { "\"width\": \($0)" },
+            height.map { "\"height\": \($0)" }
+        ]
+        .compactMap { $0 }
+        .joined(separator: ",")
+        let childFrame = childWidth.map { "\"frame\": { \"width\": \($0) }" } ?? ""
+
+        let json = """
+        {
+          "id": "scroll-container",
+          "data": {
+            "direction": "\(direction)",
+            "overflow": "SCROLL",
+            "frame": { \(frame) },
+            "children": [{
+              "__typename": "UIFlexContainerBlock",
+              "id": "label",
+              "data": { \(childFrame) }
+            }]
+          }
+        }
+        """
+        return try JSONDecoder().decode(UIFlexContainerBlock.self, from: Data(json.utf8))
+    }
+
+    private func makeDefaultRowBlock() throws -> UIFlexContainerBlock {
+        let json = """
+        {
+          "id": "parent",
+          "data": {
+            "children": [{
+              "__typename": "UIFlexContainerBlock",
+              "id": "child",
+              "data": { "frame": { "width": 0 } }
+            }]
+          }
+        }
+        """
+        return try JSONDecoder().decode(UIFlexContainerBlock.self, from: Data(json.utf8))
+    }
+}


### PR DESCRIPTION
## Summary
- resolve implicit flex directions before propagating layout context
- preserve percentage-based minimum dimensions in overflow content
- let scroll content hug its unconstrained axis

## Testing
- xcodebuild -workspace Nubrick.xcworkspace -scheme NubrickTests -destination id=CB6AF179-1592-47CD-B3D5-06CB105F1F8D -only-testing:NubrickTests/FlexOverflowViewTests test