### PR TITLE
Fix hidden flex overflow

### DIFF
--- a/Sources/Nubrick/Component/renderer/block.swift
+++ b/Sources/Nubrick/Component/renderer/block.swift
@@ -23,7 +23,7 @@ func uiblockToUIView(data: UIBlock, context: UIBlockContext) -> UIView {
     switch data {
     case .EUIFlexContainerBlock(let block):
         switch block.data?.overflow {
-        case .SCROLL, .HIDDEN:
+        case .SCROLL:
             return FlexOverflowView(block: block, context: context)
         default:
             return FlexView(block: block, context: context)

--- a/Sources/Nubrick/Component/renderer/flex.swift
+++ b/Sources/Nubrick/Component/renderer/flex.swift
@@ -22,7 +22,7 @@ private func minimumSizePreservingUnit(_ size: YGValue) -> YGValue {
 class FlexView: AnimatedUIView, BackgroundImageObserver {
     private var block: UIFlexContainerBlock = UIFlexContainerBlock()
     private var context: UIBlockContext?
-    private var isOverflowView = false
+    private var isScrollContentView = false
     var cancellables = Set<AnyCancellable>()
     var backgroundImageLoadTask: Task<Void, Never>?
 
@@ -34,21 +34,36 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
         super.init(frame: .zero)
         self.block = block
         self.context = context
-        initialize(block: block, context: context, childFlexShrink: nil)
+        initialize(
+            block: block, context: context, childFlexShrink: nil,
+            isScrollContentView: false
+        )
     }
 
-    init(block: UIFlexContainerBlock, context: UIBlockContext, childFlexShrink: Int?) {
+    init(
+        block: UIFlexContainerBlock, context: UIBlockContext, childFlexShrink: Int?,
+        isScrollContentView: Bool
+    ) {
         super.init(frame: .zero)
         self.block = block
         self.context = context
-        initialize(block: block, context: context, childFlexShrink: childFlexShrink)
+        initialize(
+            block: block, context: context, childFlexShrink: childFlexShrink,
+            isScrollContentView: isScrollContentView
+        )
     }
 
-    func initialize(block: UIFlexContainerBlock, context: UIBlockContext, childFlexShrink: Int?) {
+    func initialize(
+        block: UIFlexContainerBlock, context: UIBlockContext, childFlexShrink: Int?,
+        isScrollContentView: Bool
+    ) {
         let resolvedDirection = resolvedFlexDirection(block.data?.direction)
         let direction = parseDirection(resolvedDirection)
-        self.isOverflowView =
-            block.data?.overflow == Overflow.SCROLL || block.data?.overflow == Overflow.HIDDEN
+        // Only the inner content view created by FlexOverflowView skips its
+        // own border configuration. HIDDEN uses normal flex measurement and
+        // differs from VISIBLE solely by UIKit clipping.
+        self.isScrollContentView = isScrollContentView
+        self.clipsToBounds = block.data?.overflow == Overflow.HIDDEN
         self.configureLayout { layout in
             layout.isEnabled = true
             layout.display = .flex
@@ -133,7 +148,7 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        if !isOverflowView {
+        if !isScrollContentView {
             configureBorder(view: self, frame: self.block.data?.frame)
         }
     }
@@ -188,7 +203,10 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
         let childContext = context.instanciateFrom(
             UIBlockContextChildInit(parentDirection: resolvedDirection)
         )
-        let flexView = FlexView(block: block, context: childContext, childFlexShrink: 0)  // set child's size to shrink 0.
+        let flexView = FlexView(
+            block: block, context: childContext, childFlexShrink: 0,
+            isScrollContentView: true
+        )
         flexView.configureLayout { layout in
             if direction == .column {
                 layout.maxHeight = YGValueUndefined

--- a/Tests/NubrickTests/Component/flex.swift
+++ b/Tests/NubrickTests/Component/flex.swift
@@ -74,6 +74,36 @@ final class FlexOverflowViewTests: XCTestCase {
         XCTAssertEqual(child.yoga.minWidth.unit, .percent)
     }
 
+    @MainActor
+    func testHiddenFlexUsesNormalFlexLayoutAndClips() throws {
+        let block = try makeOverflowBlock(overflow: "HIDDEN")
+        let context = UIBlockContext(UIBlockContextInit())
+
+        let view = uiblockToUIView(data: .EUIFlexContainerBlock(block), context: context)
+
+        XCTAssertTrue(view is FlexView)
+        XCTAssertFalse(view is FlexOverflowView)
+        XCTAssertTrue(view.clipsToBounds)
+    }
+
+    @MainActor
+    func testVisibleAndHiddenFlexHaveTheSameYogaSizing() throws {
+        let context = UIBlockContext(UIBlockContextInit())
+        let visible = FlexView(
+            block: try makeOverflowBlock(overflow: "VISIBLE"), context: context
+        )
+        let hidden = FlexView(
+            block: try makeOverflowBlock(overflow: "HIDDEN"), context: context
+        )
+
+        XCTAssertEqual(visible.yoga.width.value, hidden.yoga.width.value)
+        XCTAssertEqual(visible.yoga.width.unit, hidden.yoga.width.unit)
+        XCTAssertEqual(visible.yoga.height.value, hidden.yoga.height.value)
+        XCTAssertEqual(visible.yoga.height.unit, hidden.yoga.height.unit)
+        XCTAssertFalse(visible.clipsToBounds)
+        XCTAssertTrue(hidden.clipsToBounds)
+    }
+
     private func makeScrollBlock(
         direction: String,
         width: Int?,
@@ -116,6 +146,21 @@ final class FlexOverflowViewTests: XCTestCase {
               "id": "child",
               "data": { "frame": { "width": 0 } }
             }]
+          }
+        }
+        """
+        return try JSONDecoder().decode(UIFlexContainerBlock.self, from: Data(json.utf8))
+    }
+
+    private func makeOverflowBlock(overflow: String) throws -> UIFlexContainerBlock {
+        let json = """
+        {
+          "id": "overflow-container",
+          "data": {
+            "direction": "COLUMN",
+            "overflow": "\(overflow)",
+            "frame": { "width": 0, "height": 0 },
+            "children": []
           }
         }
         """


### PR DESCRIPTION
## Summary
- render hidden-overflow flex containers as normal flex views
- clip hidden-overflow content with UIKit instead of scroll-view sizing behavior
- cover hidden overflow rendering and sizing behavior

## Testing
- `xcodebuild -workspace Nubrick.xcworkspace -scheme NubrickTests -destination "platform=iOS Simulator,id=476B6CEC-ABBB-49CF-94FF-B79677B496BF" test -only-testing:NubrickTests/FlexOverflowViewTests`