### PR TITLE
fix: return nil when variant weight sum is non-positive

### DIFF
--- a/Examples/Example/Configuration/Local.xcconfig
+++ b/Examples/Example/Configuration/Local.xcconfig
@@ -1,0 +1,8 @@
+//
+//  Local.xcconfig
+//  Example
+//
+//  Created by Takuma Jimbo on 2025/06/02.
+//
+
+PROJECT_ID=<your-project-id-here>

--- a/Examples/Example/Configuration/Local.xcconfig
+++ b/Examples/Example/Configuration/Local.xcconfig
@@ -1,8 +1,0 @@
-//
-//  Local.xcconfig
-//  Example
-//
-//  Created by Takuma Jimbo on 2025/06/02.
-//
-
-PROJECT_ID=<your-project-id-here>

--- a/Sources/Nubrick/Data/extraction/extraction.swift
+++ b/Sources/Nubrick/Data/extraction/extraction.swift
@@ -34,13 +34,19 @@ func extractExperimentVariant(config: ExperimentConfig, normalizedUsrRnd: Double
         return baseline
     }
 
-    let baselineWeight = baseline.weight ?? 1
+    // Null weight defaults to 1; negative weights are clamped to 0 so CDF stays well-defined.
+    let baselineWeight = max(0, baseline.weight ?? 1)
     var weights = [baselineWeight]
     var weightSum = baselineWeight
     for variant in variants {
-        let variantWeight = variant.weight ?? 1
+        let variantWeight = max(0, variant.weight ?? 1)
         weights.append(variantWeight)
         weightSum += variantWeight
+    }
+    // All-zero (or clamped-to-zero) weights would yield NaN probabilities and silently
+    // fall through to baseline; treat as no selectable variant instead.
+    if weightSum <= 0 {
+        return nil
     }
 
     // here is calculation of the picking from the probability.

--- a/Tests/NubrickTests/Data/extraction/extractionTests.swift
+++ b/Tests/NubrickTests/Data/extraction/extractionTests.swift
@@ -69,6 +69,44 @@ final class ExtractionTests: XCTestCase {
         let baseline = extractExperimentVariant(config: config, normalizedUsrRnd: 1.0)
         XCTAssertEqual(baseline?.id, config.baseline?.id)
     }
+
+    func testExtractExperimentVariantShouldReturnNilWhenAllWeightsAreZero() throws {
+        let config = ExperimentConfig(
+            baseline: ExperimentVariant(id: "baseline", weight: 0),
+            variants: [
+                ExperimentVariant(id: "a", weight: 0),
+                ExperimentVariant(id: "b", weight: 0),
+            ]
+        )
+        XCTAssertNil(extractExperimentVariant(config: config, normalizedUsrRnd: 0.0))
+        XCTAssertNil(extractExperimentVariant(config: config, normalizedUsrRnd: 0.5))
+        XCTAssertNil(extractExperimentVariant(config: config, normalizedUsrRnd: 1.0))
+    }
+
+    func testExtractExperimentVariantShouldReturnNilWhenWeightsAreNegativeAndSumToNonPositive() throws {
+        let config = ExperimentConfig(
+            baseline: ExperimentVariant(id: "baseline", weight: -1),
+            variants: [
+                ExperimentVariant(id: "a", weight: -2),
+            ]
+        )
+        XCTAssertNil(extractExperimentVariant(config: config, normalizedUsrRnd: 0.5))
+    }
+
+    func testExtractExperimentVariantShouldClampNegativeWeightsAndSelectPositiveOnes() throws {
+        let config = ExperimentConfig(
+            baseline: ExperimentVariant(id: "baseline", weight: -5),
+            variants: [
+                ExperimentVariant(id: "a", weight: 1),
+                ExperimentVariant(id: "b", weight: 1),
+            ]
+        )
+        // After clamping, weights are [0, 1, 1] → equal chance for a and b.
+        XCTAssertEqual(extractExperimentVariant(config: config, normalizedUsrRnd: 0.01)?.id, "a")
+        XCTAssertEqual(extractExperimentVariant(config: config, normalizedUsrRnd: 0.49)?.id, "a")
+        XCTAssertEqual(extractExperimentVariant(config: config, normalizedUsrRnd: 0.51)?.id, "b")
+        XCTAssertEqual(extractExperimentVariant(config: config, normalizedUsrRnd: 0.99)?.id, "b")
+    }
     
     func testIsInDistributionShouldBeTrue() throws {
         let userId = "hello"


### PR DESCRIPTION
## Summary
- When clamped variant weights sum to `<= 0`, `extractExperimentVariant` returns `nil` instead of silently picking baseline via NaN CDF comparisons
- Negative weights are clamped to `0` before probability calculation
- Adds regression coverage for all-zero, all-negative, and mixed negative/positive weights

## Test plan
- [x] `xcodebuild test -workspace ./Nubrick.xcworkspace -scheme NubrickTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:NubrickTests/ExtractionTests/testExtractExperimentVariantShouldReturnNilWhenAllWeightsAreZero -only-testing:NubrickTests/ExtractionTests/testExtractExperimentVariantShouldReturnNilWhenWeightsAreNegativeAndSumToNonPositive -only-testing:NubrickTests/ExtractionTests/testExtractExperimentVariantShouldClampNegativeWeightsAndSelectPositiveOnes -only-testing:NubrickTests/ExtractionTests/testExtractExperimentVariantShouldFollowWeightedProbability`


Made with [Cursor](https://cursor.com)