### PR TITLE
Fix border layout rendering

### DIFF
--- a/Sources/Nubrick/Component/renderer/collection.swift
+++ b/Sources/Nubrick/Component/renderer/collection.swift
@@ -198,6 +198,7 @@ class CollectionView: AnimatedUIView, UICollectionViewDataSource, UICollectionVi
         self.configureLayout { layout in
             layout.isEnabled = true
             layout.position = .relative
+            // Collections do not support borders in the editor, so ignore any frame border values.
             configureCollectionSize(
                 layout: layout, data: block.data, parentDirection: context.getParentDireciton()
             )
@@ -355,7 +356,6 @@ class CollectionView: AnimatedUIView, UICollectionViewDataSource, UICollectionVi
             }
         }
 
-        configureBorder(view: root, frame: self.block?.data?.frame)
     }
 
     override func sizeThatFits(_ size: CGSize) -> CGSize {

--- a/Sources/Nubrick/Component/renderer/flex.swift
+++ b/Sources/Nubrick/Component/renderer/flex.swift
@@ -72,6 +72,9 @@ class FlexView: AnimatedUIView, BackgroundImageObserver {
             layout.alignItems = parseAlignItems(block.data?.alignItems)
             layout.justifyContent = parseJustifyContent(block.data?.justifyContent)
             configurePadding(layout: layout, frame: block.data?.frame)
+            if !isScrollContentView {
+                configureBorderWidth(layout: layout, frame: block.data?.frame)
+            }
             configureSize(
                 layout: layout, frame: block.data?.frame,
                 parentDirection: context.getParentDireciton())
@@ -193,6 +196,7 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
             configureSize(
                 layout: layout, frame: block.data?.frame,
                 parentDirection: context.getParentDireciton())
+            configureBorderWidth(layout: layout, frame: block.data?.frame)
         }
         
         self.showsVerticalScrollIndicator = false
@@ -251,23 +255,31 @@ class FlexOverflowView: UIScrollView, BackgroundImageObserver {
         // This allows scroll content to grow beyond the scroll view's visible bounds
         // Set min size so inner FlexView fills at least the visible area
         let direction = parseDirection(self.block.data?.direction)
+        let borderWidth = CGFloat(max(self.block.data?.frame?.borderWidth ?? 0, 0))
         if direction == .column {
             let visibleHeight = max(
                 0,
-                self.bounds.height - self.contentInset.top - self.contentInset.bottom
+                self.bounds.height
+                    - self.contentInset.top - self.contentInset.bottom
+                    - borderWidth * 2
             )
             self.flexView.yoga.minHeight = YGValue(value: Float(visibleHeight), unit: .point)
             self.flexView.yoga.applyLayout(preservingOrigin: true, dimensionFlexibility: .flexibleHeight)
         } else {
             let visibleWidth = max(
                 0,
-                self.bounds.width - self.contentInset.left - self.contentInset.right
+                self.bounds.width
+                    - self.contentInset.left - self.contentInset.right
+                    - borderWidth * 2
             )
             self.flexView.yoga.minWidth = YGValue(value: Float(visibleWidth), unit: .point)
             self.flexView.yoga.applyLayout(preservingOrigin: true, dimensionFlexibility: .flexibleWidth)
         }
 
-        self.contentSize = self.flexView.bounds.size
+        self.contentSize = CGSize(
+            width: max(self.bounds.width, self.flexView.frame.maxX + borderWidth),
+            height: max(self.bounds.height, self.flexView.frame.maxY + borderWidth)
+        )
         configureBorder(view: self, frame: self.block.data?.frame)
     }
 

--- a/Sources/Nubrick/Component/renderer/forms.swift
+++ b/Sources/Nubrick/Component/renderer/forms.swift
@@ -170,14 +170,16 @@ class TextInputView: UIView, UITextFieldDelegate {
         textInput.font = font
         let intrinsicHeight = ceil(textInput.intrinsicContentSize.height)
         let verticalPadding = CGFloat((block.data?.frame?.paddingTop ?? 0) + (block.data?.frame?.paddingBottom ?? 0))
+        let borderHeight = CGFloat(max(block.data?.frame?.borderWidth ?? 0, 0)) * 2
 
         // wrap layout
         self.configureLayout { layout in
             layout.isEnabled = true
             layout.width = .init(value: 100.0, unit: .percent)
             configureSize(layout: layout, frame: block.data?.frame, parentDirection: context.getParentDireciton())
+            configureBorderWidth(layout: layout, frame: block.data?.frame)
             if block.data?.frame?.height == nil {
-                layout.height = .init(value: Float(intrinsicHeight + verticalPadding), unit: .point)
+                layout.height = .init(value: Float(intrinsicHeight + verticalPadding + borderHeight), unit: .point)
             }
             layout.flexShrink = 1
         }

--- a/Sources/Nubrick/Component/renderer/image.swift
+++ b/Sources/Nubrick/Component/renderer/image.swift
@@ -31,6 +31,7 @@ class ImageView: AnimatedUIView {
 
             // Image padding is not supported by the editor so we dont apply padding
             configureSize(layout: layout, frame: block.data?.frame, parentDirection: context.getParentDireciton())
+            configureBorderWidth(layout: layout, frame: block.data?.frame)
 
             // image URLs include dimensions for their blurhash
             // fallback. Use them until the full image provides exact dimensions.

--- a/Sources/Nubrick/Component/renderer/select.swift
+++ b/Sources/Nubrick/Component/renderer/select.swift
@@ -56,6 +56,7 @@ class SelectInputView: UIControl {
             layout.isEnabled = true
             layout.width = .init(value: 100.0, unit: .percent)
             layout.flexShrink = 1
+            configureBorderWidth(layout: layout, frame: self.block.data?.frame)
         }
     }
 
@@ -286,6 +287,7 @@ class MultiSelectInputView: UIControl {
             layout.flexDirection = .row
             layout.alignItems = .center
             configurePadding(layout: layout, frame: block.data?.frame)
+            configureBorderWidth(layout: layout, frame: block.data?.frame)
         }
 
         let label = UILabel(frame: .zero)

--- a/Sources/Nubrick/Component/renderer/text.swift
+++ b/Sources/Nubrick/Component/renderer/text.swift
@@ -21,6 +21,7 @@ class TextView: AnimatedUIView, BackgroundImageObserver {
             layout.isEnabled = true
             layout.display = .flex
             layout.direction = .LTR
+            configureBorderWidth(layout: layout, frame: block.data?.frame)
         }
 
         let label = UILabel()

--- a/Sources/Nubrick/Util/utils.swift
+++ b/Sources/Nubrick/Util/utils.swift
@@ -342,6 +342,13 @@ func configurePadding(layout: YGLayout, frame: FrameData?) {
     layout.paddingBottom = parseInt(frame?.paddingBottom)
 }
 
+// Yoga's border is part of its border-box calculation. Keep it in sync with
+// the visual border so child layout begins after the border, as it does in the
+// web editor's `box-sizing: border-box` implementation.
+func configureBorderWidth(layout: YGLayout, frame: FrameData?) {
+    layout.borderWidth = CGFloat(max(frame?.borderWidth ?? 0, 0))
+}
+
 func configureSize(layout: YGLayout, frame: FrameData?, parentDirection: FlexDirection?) {
     if let height = frame?.height {
         if height == 0 {  // fill
@@ -424,57 +431,15 @@ private func normalizeSingleRadius(radius: CGFloat, width: CGFloat, height: CGFl
     return radius * min(1, l / radius / 2)
 }
 
-// NOTE: should be called in viewDidLayoutSubviews to wait until view.bounds are set
-@MainActor
-func configureBorder(view: UIView, frame: FrameData?) {
-    if let bg = frame?.background {
-        view.layer.backgroundColor = parseColorToCGColor(bg)
-    }
-
-    let width = view.bounds.width
-    let height = view.bounds.height
-
-    let isSingleRadius =
-        (frame?.borderTopLeftRadius == frame?.borderTopRightRadius)
-        && (frame?.borderTopLeftRadius == frame?.borderBottomLeftRadius)
-        && (frame?.borderTopLeftRadius == frame?.borderBottomRightRadius)
-
-    if isSingleRadius {
-        // if radius is not set or single value
-        view.layer.borderWidth = CGFloat(frame?.borderWidth ?? 0)
-        if let bc = frame?.borderColor {
-            view.layer.borderColor = parseColorToCGColor(bc)
-        }
-        // Prefer borderRadius; if omitted, use the shared per-corner value
-        // (all four corners are equal when isSingleRadius is true).
-        view.layer.cornerRadius = CGFloat(
-            normalizeSingleRadius(
-                radius: CGFloat(frame?.borderRadius ?? frame?.borderTopLeftRadius ?? 0),
-                width: width,
-                height: height))
-        return
-    }
-
-    let radius = normalizeRadius(
-        radius: BorderRadius(
-            topLeft: CGFloat(frame?.borderTopLeftRadius ?? 0),
-            topRight: CGFloat(frame?.borderTopRightRadius ?? 0),
-            bottomRight: CGFloat(frame?.borderBottomRightRadius ?? 0),
-            bottomLeft: CGFloat(frame?.borderBottomLeftRadius ?? 0)
-        ),
-        width: width,
-        height: height
-    )
+private func roundedRectPath(bounds: CGRect, radius: BorderRadius) -> UIBezierPath {
     let (topLeftRadius, topRightRadius, bottomRightRadius, bottomLeftRadius) = (
         radius.topLeft, radius.topRight, radius.bottomRight, radius.bottomLeft
     )
+    let topLeft = CGPoint(x: bounds.minX, y: bounds.minY)
+    let topRight = CGPoint(x: bounds.maxX, y: bounds.minY)
+    let bottomRight = CGPoint(x: bounds.maxX, y: bounds.maxY)
+    let bottomLeft = CGPoint(x: bounds.minX, y: bounds.maxY)
 
-    let topLeft = CGPoint(x: 0, y: 0)
-    let topRight = CGPoint(x: width, y: 0)
-    let bottomRight = CGPoint(x: width, y: height)
-    let bottomLeft = CGPoint(x: 0, y: height)
-
-    // draw rect path with corner radius
     let path = UIBezierPath()
     path.move(to: CGPoint(x: topLeft.x + topLeftRadius, y: topLeft.y))
     path.addLine(to: CGPoint(x: topRight.x - topRightRadius, y: topRight.y))
@@ -507,6 +472,57 @@ func configureBorder(view: UIView, frame: FrameData?) {
         endAngle: -.pi / 2,
         clockwise: true)
     path.close()
+    return path
+}
+
+// NOTE: should be called in viewDidLayoutSubviews to wait until view.bounds are set
+@MainActor
+func configureBorder(view: UIView, frame: FrameData?) {
+    if let bg = frame?.background {
+        view.layer.backgroundColor = parseColorToCGColor(bg)
+    }
+
+    let width = view.bounds.width
+    let height = view.bounds.height
+    let drawingBounds = CGRect(origin: .zero, size: view.bounds.size)
+    let borderWidth = CGFloat(max(frame?.borderWidth ?? 0, 0))
+    let borderColor = parseColorToCGColor(frame?.borderColor)
+
+    let isSingleRadius =
+        (frame?.borderTopLeftRadius == frame?.borderTopRightRadius)
+        && (frame?.borderTopLeftRadius == frame?.borderBottomLeftRadius)
+        && (frame?.borderTopLeftRadius == frame?.borderBottomRightRadius)
+
+    if isSingleRadius {
+        // if radius is not set or single value
+        view.layer.sublayers?.filter { $0.name == "border-layer" }.forEach { $0.removeFromSuperlayer() }
+        view.layer.mask = nil
+        view.layer.borderWidth = borderWidth
+        view.layer.borderColor = borderColor
+        // Prefer borderRadius; if omitted, use the shared per-corner value
+        // (all four corners are equal when isSingleRadius is true).
+        view.layer.cornerRadius = CGFloat(
+            normalizeSingleRadius(
+                radius: CGFloat(frame?.borderRadius ?? frame?.borderTopLeftRadius ?? 0),
+                width: width,
+                height: height))
+        return
+    }
+
+    let radius = normalizeRadius(
+        radius: BorderRadius(
+            topLeft: CGFloat(frame?.borderTopLeftRadius ?? 0),
+            topRight: CGFloat(frame?.borderTopRightRadius ?? 0),
+            bottomRight: CGFloat(frame?.borderBottomRightRadius ?? 0),
+            bottomLeft: CGFloat(frame?.borderBottomLeftRadius ?? 0)
+        ),
+        width: width,
+        height: height
+    )
+    // UIScrollView changes bounds.origin as it scrolls. Sublayers use the
+    // translated view bounds for their frame so they stay fixed on screen,
+    // but their paths must remain in the layer's local coordinate space.
+    let path = roundedRectPath(bounds: drawingBounds, radius: radius)
 
     // clip corner
     let maskLayer = CAShapeLayer()
@@ -515,16 +531,33 @@ func configureBorder(view: UIView, frame: FrameData?) {
     maskLayer.fillColor = UIColor.white.cgColor
     view.layer.mask = maskLayer
 
-    // set border
+    // A shape-layer stroke is centered on its path. Inset the stroke path by
+    // half its width so its outer edge aligns with the view bounds instead of
+    // being clipped by the corner mask.
+    let strokeInset = min(borderWidth / 2, max(0, min(width, height) / 2))
+    let strokeBounds = drawingBounds.insetBy(dx: strokeInset, dy: strokeInset)
+    let strokeRadius = normalizeRadius(
+        radius: BorderRadius(
+            topLeft: max(0, radius.topLeft - strokeInset),
+            topRight: max(0, radius.topRight - strokeInset),
+            bottomRight: max(0, radius.bottomRight - strokeInset),
+            bottomLeft: max(0, radius.bottomLeft - strokeInset)
+        ),
+        width: strokeBounds.width,
+        height: strokeBounds.height
+    )
+
+    view.layer.borderWidth = 0
+    view.layer.borderColor = CGColor(gray: 0, alpha: 0)
+    view.layer.cornerRadius = 0
+
     let shapeLayer = CAShapeLayer()
     shapeLayer.frame = view.bounds
-    shapeLayer.path = path.cgPath
-    shapeLayer.lineWidth = CGFloat(frame?.borderWidth ?? 0)
+    shapeLayer.path = roundedRectPath(bounds: strokeBounds, radius: strokeRadius).cgPath
+    shapeLayer.lineWidth = borderWidth
     shapeLayer.fillColor = UIColor.clear.cgColor
+    shapeLayer.strokeColor = borderColor
     shapeLayer.name = "border-layer"
-    if let bc = frame?.borderColor {
-        shapeLayer.strokeColor = parseColorToCGColor(bc)
-    }
     view.layer.sublayers?.filter { $0.name == "border-layer" }.forEach { $0.removeFromSuperlayer() }
     view.layer.addSublayer(shapeLayer)
 }

--- a/Tests/NubrickTests/Component/flex.swift
+++ b/Tests/NubrickTests/Component/flex.swift
@@ -228,8 +228,10 @@ final class FlexOverflowViewTests: XCTestCase {
         return try JSONDecoder().decode(UIFlexContainerBlock.self, from: Data(json.utf8))
     }
 
+    @MainActor
     private func scrollContent(of view: FlexOverflowView) throws -> UIView {
-        try XCTUnwrap(view.subviews.first { $0 is FlexView })
+        let content = view.subviews.first { $0 is FlexView }
+        return try XCTUnwrap(content)
     }
 
     private func makeDefaultRowBlock() throws -> UIFlexContainerBlock {

--- a/Tests/NubrickTests/Component/flex.swift
+++ b/Tests/NubrickTests/Component/flex.swift
@@ -23,7 +23,7 @@ final class FlexOverflowViewTests: XCTestCase {
             context: UIBlockContext(UIBlockContextInit())
         )
 
-        let content = try XCTUnwrap(view.subviews.first)
+        let content = try scrollContent(of: view)
         XCTAssertTrue(content.yoga.height.value.isNaN)
     }
 
@@ -34,7 +34,7 @@ final class FlexOverflowViewTests: XCTestCase {
             context: UIBlockContext(UIBlockContextInit())
         )
 
-        let content = try XCTUnwrap(view.subviews.first)
+        let content = try scrollContent(of: view)
         XCTAssertEqual(content.yoga.height.value, 100)
     }
 
@@ -45,7 +45,7 @@ final class FlexOverflowViewTests: XCTestCase {
             context: UIBlockContext(UIBlockContextInit())
         )
 
-        let content = try XCTUnwrap(view.subviews.first)
+        let content = try scrollContent(of: view)
         XCTAssertTrue(content.yoga.width.value.isNaN)
     }
 
@@ -56,7 +56,7 @@ final class FlexOverflowViewTests: XCTestCase {
             context: UIBlockContext(UIBlockContextInit())
         )
 
-        let content = try XCTUnwrap(view.subviews.first)
+        let content = try scrollContent(of: view)
         XCTAssertEqual(content.yoga.width.value, 100)
     }
 
@@ -69,7 +69,7 @@ final class FlexOverflowViewTests: XCTestCase {
             context: UIBlockContext(UIBlockContextInit())
         )
 
-        let content = try XCTUnwrap(view.subviews.first)
+        let content = try scrollContent(of: view)
         let child = try XCTUnwrap(content.subviews.first)
         XCTAssertEqual(child.yoga.minWidth.unit, .percent)
     }
@@ -104,19 +104,111 @@ final class FlexOverflowViewTests: XCTestCase {
         XCTAssertTrue(hidden.clipsToBounds)
     }
 
+    @MainActor
+    func testBorderWidthIsIncludedInFlexYogaBoxModel() throws {
+        let root = FlexView(
+            block: try makeBorderedBlock(),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+
+        XCTAssertEqual(root.yoga.borderWidth, 2)
+    }
+
+    @MainActor
+    func testScrollContentDoesNotReserveTheContainerBorderTwice() throws {
+        let view = FlexOverflowView(
+            block: try makeScrollBlock(
+                direction: "COLUMN", width: 100, height: 100, borderWidth: 2
+            ),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+
+        XCTAssertEqual(view.yoga.borderWidth, 2)
+        XCTAssertTrue(try scrollContent(of: view).yoga.borderWidth.isNaN)
+    }
+
+    @MainActor
+    func testScrollLayoutWithoutBorderProducesFiniteGeometry() throws {
+        let view = FlexOverflowView(
+            block: try makeScrollBlock(direction: "COLUMN", width: 100, height: 100),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+        view.frame.size = CGSize(width: 100, height: 100)
+        view.yoga.applyLayout(preservingOrigin: true)
+        view.layoutSubviews()
+
+        XCTAssertTrue(view.contentSize.width.isFinite)
+        XCTAssertTrue(view.contentSize.height.isFinite)
+    }
+
+    @MainActor
+    func testVerticalScrollContentFillsBorderAdjustedViewport() throws {
+        let view = FlexOverflowView(
+            block: try makeScrollBlock(
+                direction: "COLUMN", width: 100, height: 100, borderWidth: 2
+            ),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+        view.frame.size = CGSize(width: 100, height: 100)
+        view.yoga.applyLayout(preservingOrigin: true)
+        view.layoutSubviews()
+
+        XCTAssertEqual(try scrollContent(of: view).frame, CGRect(x: 2, y: 2, width: 96, height: 96))
+        XCTAssertEqual(view.contentSize.height, 100)
+    }
+
+    @MainActor
+    func testHorizontalScrollContentFillsBorderAdjustedViewport() throws {
+        let view = FlexOverflowView(
+            block: try makeScrollBlock(
+                direction: "ROW", width: 100, height: 100, borderWidth: 2
+            ),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+        view.frame.size = CGSize(width: 100, height: 100)
+        view.layoutSubviews()
+
+        XCTAssertEqual(view.contentSize.width, 100)
+    }
+
+    @MainActor
+    func testVerticalScrollContentSizeIncludesTrailingBorder() throws {
+        let view = FlexOverflowView(
+            block: try makeScrollBlock(
+                direction: "COLUMN", width: 100, height: 100, childHeight: 200, borderWidth: 2
+            ),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+        view.frame.size = CGSize(width: 100, height: 100)
+        view.yoga.applyLayout(preservingOrigin: true)
+        view.layoutSubviews()
+
+        XCTAssertEqual(try scrollContent(of: view).frame, CGRect(x: 2, y: 2, width: 96, height: 200))
+        XCTAssertEqual(view.contentSize, CGSize(width: 100, height: 204))
+    }
+
     private func makeScrollBlock(
         direction: String,
         width: Int?,
         height: Int?,
-        childWidth: Int? = nil
+        childWidth: Int? = nil,
+        childHeight: Int? = nil,
+        borderWidth: Int? = nil
     ) throws -> UIFlexContainerBlock {
         let frame = [
             width.map { "\"width\": \($0)" },
-            height.map { "\"height\": \($0)" }
+            height.map { "\"height\": \($0)" },
+            borderWidth.map { "\"borderWidth\": \($0)" }
         ]
         .compactMap { $0 }
         .joined(separator: ",")
-        let childFrame = childWidth.map { "\"frame\": { \"width\": \($0) }" } ?? ""
+        let childFrameValues = [
+            childWidth.map { "\"width\": \($0)" },
+            childHeight.map { "\"height\": \($0)" }
+        ]
+        .compactMap { $0 }
+        .joined(separator: ",")
+        let childFrame = childFrameValues.isEmpty ? "" : "\"frame\": { \(childFrameValues) }"
 
         let json = """
         {
@@ -134,6 +226,10 @@ final class FlexOverflowViewTests: XCTestCase {
         }
         """
         return try JSONDecoder().decode(UIFlexContainerBlock.self, from: Data(json.utf8))
+    }
+
+    private func scrollContent(of view: FlexOverflowView) throws -> UIView {
+        try XCTUnwrap(view.subviews.first { $0 is FlexView })
     }
 
     private func makeDefaultRowBlock() throws -> UIFlexContainerBlock {
@@ -160,6 +256,19 @@ final class FlexOverflowViewTests: XCTestCase {
             "direction": "COLUMN",
             "overflow": "\(overflow)",
             "frame": { "width": 0, "height": 0 },
+            "children": []
+          }
+        }
+        """
+        return try JSONDecoder().decode(UIFlexContainerBlock.self, from: Data(json.utf8))
+    }
+
+    private func makeBorderedBlock() throws -> UIFlexContainerBlock {
+        let json = """
+        {
+          "id": "bordered-container",
+          "data": {
+            "frame": { "width": 100, "height": 100, "borderWidth": 2 },
             "children": []
           }
         }

--- a/Tests/NubrickTests/Component/forms.swift
+++ b/Tests/NubrickTests/Component/forms.swift
@@ -1,0 +1,37 @@
+import UIKit
+import XCTest
+@testable import NubrickLocal
+import YogaKit
+
+final class TextInputViewTests: XCTestCase {
+    @MainActor
+    func testAutoHeightIncludesBorderWidth() throws {
+        let input = TextInputView(
+            block: try makeTextInputBlock(),
+            context: UIBlockContext(UIBlockContextInit())
+        )
+        let textField = try XCTUnwrap(input.subviews.first as? UITextField)
+
+        XCTAssertEqual(input.yoga.borderWidth, 2)
+        XCTAssertEqual(
+            input.yoga.height.value,
+            Float(ceil(textField.intrinsicContentSize.height) + 12 + 4)
+        )
+    }
+
+    private func makeTextInputBlock() throws -> UITextInputBlock {
+        let json = """
+        {
+          "id": "input",
+          "data": {
+            "frame": {
+              "paddingTop": 5,
+              "paddingBottom": 7,
+              "borderWidth": 2
+            }
+          }
+        }
+        """
+        return try JSONDecoder().decode(UITextInputBlock.self, from: Data(json.utf8))
+    }
+}

--- a/Tests/NubrickTests/Util/utils.swift
+++ b/Tests/NubrickTests/Util/utils.swift
@@ -1,3 +1,4 @@
+import UIKit
 import XCTest
 @testable import NubrickLocal
 
@@ -22,5 +23,36 @@ final class ImageUtilTests: XCTestCase {
         XCTAssertTrue(hasMissingImageDimension(width: 200, height: nil))
         XCTAssertTrue(hasMissingImageDimension(width: nil, height: 200))
         XCTAssertFalse(hasMissingImageDimension(width: 200, height: 100))
+    }
+}
+
+final class BorderUtilTests: XCTestCase {
+    @MainActor
+    func testAsymmetricBorderPathRemainsLocalWhenScrollViewScrolls() throws {
+        let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        scrollView.bounds.origin = CGPoint(x: 20, y: 30)
+        let frame = try JSONDecoder().decode(
+            FrameData.self,
+            from: Data(
+                """
+                {
+                  "borderWidth": 2,
+                  "borderTopLeftRadius": 8,
+                  "borderTopRightRadius": 4,
+                  "borderBottomRightRadius": 2,
+                  "borderBottomLeftRadius": 0
+                }
+                """.utf8
+            )
+        )
+
+        configureBorder(view: scrollView, frame: frame)
+
+        let borderLayer = try XCTUnwrap(
+            scrollView.layer.sublayers?.first { $0.name == "border-layer" } as? CAShapeLayer
+        )
+        let path = try XCTUnwrap(borderLayer.path)
+        XCTAssertEqual(borderLayer.frame, scrollView.bounds)
+        XCTAssertEqual(path.boundingBoxOfPath, CGRect(x: 1, y: 1, width: 98, height: 98))
     }
 }


### PR DESCRIPTION
Summary:
- Include frame border width in Yoga box-model calculations.
- Keep scrollable flex content and asymmetric border rendering aligned with the visible border.
- Add coverage for border sizing, scrolling, and form input auto-height.

Tests:
- xcodebuild test -workspace Nubrick.xcworkspace -scheme NubrickTests -destination platform=iOS Simulator,id=476B6CEC-ABBB-49CF-94FF-B79677B496BF -only-testing:NubrickTests