### PR TITLE
Harden renderer input validation

### DIFF
--- a/Sources/Nubrick/Component/renderer/collection.swift
+++ b/Sources/Nubrick/Component/renderer/collection.swift
@@ -279,6 +279,9 @@ class CollectionView: AnimatedUIView, UICollectionViewDataSource, UICollectionVi
         guard self.shouldAutoScroll() else { return }
 
         let timeInterval = self.block?.data?.autoScrollInterval ?? 3.0
+        guard timeInterval.isFinite, timeInterval > 0 else {
+            return
+        }
         self.timer = Timer.scheduledTimer(withTimeInterval: TimeInterval(timeInterval), repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.automaticScroll()

--- a/Sources/Nubrick/Component/renderer/select.swift
+++ b/Sources/Nubrick/Component/renderer/select.swift
@@ -237,7 +237,7 @@ class MultiSelectTableViewController: UIViewController, UITableViewDelegate, UIT
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "MyCell", for: indexPath as IndexPath)
         let cellOption = self.options[indexPath.row]
-        cell.textLabel!.text = "\(cellOption.value ?? "")"
+        cell.textLabel?.text = "\(cellOption.value ?? "")"
         let selectedCellOption = self.selectedOptions.first(where: { option in
            if option.value == cellOption.value {
                return true

--- a/Sources/Nubrick/vendor/blurhash.swift
+++ b/Sources/Nubrick/vendor/blurhash.swift
@@ -6,7 +6,16 @@ import UIKit
 
 extension UIImage {
     convenience init?(blurHash: String, size: CGSize, punch: Float = 1) {
-        guard blurHash.count >= 6 else { return nil }
+        guard
+            blurHash.count >= 6,
+            blurHash.allSatisfy({ decodeCharacters[String($0)] != nil }),
+            size.width.isFinite,
+            size.height.isFinite,
+            size.width > 0,
+            size.height > 0
+        else {
+            return nil
+        }
 
         let sizeFlag = String(blurHash[0]).decode83()
         let numY = (sizeFlag / 9) + 1
@@ -27,8 +36,13 @@ extension UIImage {
             }
         }
 
-        let width = Int(size.width)
-        let height = Int(size.height)
+        // The dimensions come from image URL metadata. A compact fallback does
+        // not need source-resolution pixels, and bounding it prevents malformed
+        // URLs from causing an excessive allocation.
+        let maximumDimension: CGFloat = 512
+        let scale = min(1, maximumDimension / max(size.width, size.height))
+        let width = max(1, Int((size.width * scale).rounded()))
+        let height = max(1, Int((size.height * scale).rounded()))
         let bytesPerRow = width * 3
         guard let data = CFDataCreateMutable(kCFAllocatorDefault, bytesPerRow * height) else { return nil }
         CFDataSetLength(data, bytesPerRow * height)


### PR DESCRIPTION
## Summary
- reject invalid carousel auto-scroll intervals before creating timers
- safely handle cells without a text label
- validate and bound BlurHash fallback image dimensions

## Validation
- xcodebuild -project Nubrick/Nubrick.xcodeproj -scheme Nubrick -destination "generic/platform=iOS Simulator" build