### PR TITLE
Harden distribution evaluation

### DIFF
--- a/Sources/Nubrick/Data/extraction/extraction.swift
+++ b/Sources/Nubrick/Data/extraction/extraction.swift
@@ -137,7 +137,13 @@ func extractExperimentConfigMatchedToProperties(
     }
 }
 
-func isInDistribution(distribution: [ExperimentCondition], properties: [UserProperty]) -> Bool {
+func isInDistribution(distribution: [ExperimentCondition], properties: [UserProperty]) async -> Bool {
+    await Task.detached(priority: .userInitiated) {
+        isInDistributionSync(distribution: distribution, properties: properties)
+    }.value
+}
+
+private func isInDistributionSync(distribution: [ExperimentCondition], properties: [UserProperty]) -> Bool {
     let props = Dictionary(uniqueKeysWithValues: properties.map({ property in
         return (property.name, property)
     }))
@@ -512,7 +518,17 @@ func compareSemver(a: String, b: [String], op: ConditionOperator) -> Bool {
     }
 }
 
+// Distribution-condition patterns are configured remotely, so reject excessively large values
+// before compiling or evaluating them.
+private let maximumRegexPatternLength = 1_000
+private let maximumRegexInputLength = 10_000
+
 func containsPattern(_ input: String, _ pattern: String) -> Bool {
+    guard input.utf16.count <= maximumRegexInputLength,
+          pattern.utf16.count <= maximumRegexPatternLength else {
+        return false
+    }
+
     if #available(iOS 16.0, *) {
         do {
             let regex = try Regex(pattern)

--- a/Tests/NubrickTests/Data/extraction/extractionTests.swift
+++ b/Tests/NubrickTests/Data/extraction/extractionTests.swift
@@ -108,7 +108,7 @@ final class ExtractionTests: XCTestCase {
         XCTAssertEqual(extractExperimentVariant(config: config, normalizedUsrRnd: 0.99)?.id, "b")
     }
     
-    func testIsInDistributionShouldBeTrue() throws {
+    func testIsInDistributionShouldBeTrue() async throws {
         let userId = "hello"
         let userRnd = "50"
         let distribution: [ExperimentCondition] = [
@@ -121,22 +121,22 @@ final class ExtractionTests: XCTestCase {
             UserProperty(name: "else", value: "world", type: .STRING),
         ]
         
-        let actual = isInDistribution(distribution: distribution, properties: props)
+        let actual = await isInDistribution(distribution: distribution, properties: props)
         XCTAssertTrue(actual)
     }
     
-    func testIsInDistributionShouldBeTrueWhenZeroConditions() throws {
+    func testIsInDistributionShouldBeTrueWhenZeroConditions() async throws {
         let userId = "hello"
         let distribution: [ExperimentCondition] = []
         let props: [UserProperty] = [
             UserProperty(name: "userId", value: userId, type: .STRING),
         ]
         
-        let actual = isInDistribution(distribution: distribution, properties: props)
+        let actual = await isInDistribution(distribution: distribution, properties: props)
         XCTAssertTrue(actual)
     }
     
-    func testIsInDistributionShouldBeFalse() throws {
+    func testIsInDistributionShouldBeFalse() async throws {
         let userId = "hello"
         let userRnd = "50"
         let distribution: [ExperimentCondition] = [
@@ -149,10 +149,10 @@ final class ExtractionTests: XCTestCase {
             UserProperty(name: "else", value: "world", type: .STRING),
         ]
         
-        let actual = isInDistribution(distribution: distribution, properties: props)
+        let actual = await isInDistribution(distribution: distribution, properties: props)
         XCTAssertFalse(actual)
     }
-    
+
     func testExtractExperimentConfigMatchedToPropertiesShouldReturnNilWhenItsZeroConfig() async throws {
         let actual = await extractExperimentConfigMatchedToProperties(configs: ExperimentConfigs(configs: []), kinds: [.POPUP]) { seed in
             return []
@@ -630,7 +630,20 @@ final class CompareTests: XCTestCase {
     func testCompareStringWithRegexShouldBeFalseWhenThePatternIsWrong() throws {
         XCTAssertFalse(compareString(a: "+", b: ["+"], op: .Regex))
     }
-    
+
+    func testCompareStringWithRegexRejectsOversizedInput() throws {
+        XCTAssertFalse(compareString(
+            a: String(repeating: "a", count: 10_001),
+            b: ["^a+$"],
+            op: .Regex
+        ))
+    }
+
+    func testCompareStringWithRegexRejectsOversizedPattern() throws {
+        let longLiteral = String(repeating: "a", count: 1_001)
+        XCTAssertFalse(compareString(a: longLiteral, b: [longLiteral], op: .Regex))
+    }
+
     func testCompareDouble() throws {
         // equal
         XCTAssertTrue(compareDouble(a: 0, b: [0], op: .Equal))


### PR DESCRIPTION
## Summary

- Evaluate distribution conditions asynchronously so matching work does not run on the caller executor.
- Reject oversized regex inputs and patterns before evaluation.
- Add coverage for regex limits and async distribution matching.

## Testing

- `xcodebuild -project Nubrick/Nubrick.xcodeproj -scheme Nubrick -destination 'generic/platform=iOS Simulator' build`