### PR TITLE
Normalize TIMESTAMPZ parsing to UTC

### DIFF
--- a/Sources/Nubrick/Data/extraction/extraction.swift
+++ b/Sources/Nubrick/Data/extraction/extraction.swift
@@ -232,20 +232,24 @@ func comparePropWithConditionValue(prop: UserProperty, asType: UserPropertyType?
     }
 }
 
+private let timestampZTimeZone = TimeZone(secondsFromGMT: 0)!
+
 private let iso8601ParseStrategies: [Date.ISO8601FormatStyle] = [
-    .iso8601.year().month().day().time(includingFractionalSeconds: true).timeZone(separator: .colon),
-    .iso8601.year().month().day().time(includingFractionalSeconds: false).timeZone(separator: .colon),
-    .iso8601.year().month().day().time(includingFractionalSeconds: true).timeZone(separator: .omitted),
-    .iso8601.year().month().day().time(includingFractionalSeconds: false).timeZone(separator: .omitted),
-    .iso8601.year().month().day().time(includingFractionalSeconds: false),
-    .iso8601.year().month().day(),
+    Date.ISO8601FormatStyle(timeZone: timestampZTimeZone).year().month().day().time(includingFractionalSeconds: true).timeZone(separator: .colon),
+    Date.ISO8601FormatStyle(timeZone: timestampZTimeZone).year().month().day().time(includingFractionalSeconds: false).timeZone(separator: .colon),
+    Date.ISO8601FormatStyle(timeZone: timestampZTimeZone).year().month().day().time(includingFractionalSeconds: true).timeZone(separator: .omitted),
+    Date.ISO8601FormatStyle(timeZone: timestampZTimeZone).year().month().day().time(includingFractionalSeconds: false).timeZone(separator: .omitted),
+    Date.ISO8601FormatStyle(timeZone: timestampZTimeZone).year().month().day().time(includingFractionalSeconds: false),
+    Date.ISO8601FormatStyle(timeZone: timestampZTimeZone).year().month().day(),
 ]
 
 private let fallbackParseStrategy = Date.ParseStrategy(
     format: "\(year: .defaultDigits)-\(month: .twoDigits)-\(day: .twoDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits):\(second: .twoDigits) \(timeZone: .iso8601(.short))",
     locale: Locale(identifier: "en_US_POSIX"),
-    timeZone: .current
+    timeZone: timestampZTimeZone
 )
+
+private let localISO8601DateTimePattern = #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$"#
 
 func parseTimestampZAsUnixSeconds(_ value: String) -> Double? {
     let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -260,6 +264,16 @@ func parseTimestampZAsUnixSeconds(_ value: String) -> Double? {
     for strategy in iso8601ParseStrategies {
         if let date = try? Date(trimmed, strategy: strategy) {
             return Double(Int64(date.timeIntervalSince1970))
+        }
+    }
+
+    // TIMESTAMPZ values without an offset are defined as UTC so conditions have
+    // identical results regardless of the device's configured time zone.
+    if trimmed.range(of: localISO8601DateTimePattern, options: .regularExpression) != nil {
+        for strategy in iso8601ParseStrategies {
+            if let date = try? Date("\(trimmed)Z", strategy: strategy) {
+                return Double(Int64(date.timeIntervalSince1970))
+            }
         }
     }
 

--- a/Tests/NubrickTests/Data/extraction/extractionTests.swift
+++ b/Tests/NubrickTests/Data/extraction/extractionTests.swift
@@ -484,6 +484,25 @@ final class CompareTests: XCTestCase {
         ))
     }
 
+    func testParseTimestampZNormalizesLocalISO8601DateTimeToUTC() throws {
+        let expected = parseTimestampZAsUnixSeconds("2024-06-01T09:30:00Z")
+
+        XCTAssertEqual(parseTimestampZAsUnixSeconds("2024-06-01T09:30:00"), expected)
+        XCTAssertEqual(parseTimestampZAsUnixSeconds("2024-06-01T09:30:00.500"), expected)
+    }
+
+    func testParseTimestampZLocalISO8601DateTimeIsIndependentOfDefaultTimeZone() throws {
+        let originalTimeZone = NSTimeZone.default
+        defer { NSTimeZone.default = originalTimeZone }
+
+        let expected = parseTimestampZAsUnixSeconds("2024-06-01T09:30:00Z")
+        for identifier in ["America/Los_Angeles", "Asia/Tokyo"] {
+            NSTimeZone.default = try XCTUnwrap(TimeZone(identifier: identifier))
+            XCTAssertEqual(parseTimestampZAsUnixSeconds("2024-06-01T09:30:00"), expected)
+            XCTAssertEqual(parseTimestampZAsUnixSeconds("2024-06-01"), parseTimestampZAsUnixSeconds("2024-06-01T00:00:00Z"))
+        }
+    }
+
     func testCompareTimestampZWithLocalDateString() throws {
         let prop = UserProperty(
             name: BuiltinUserProperty.currentTime.rawValue,


### PR DESCRIPTION
## Summary

- Normalize offset-less TIMESTAMPZ values as UTC.
- Ensure date parsing does not vary with the device time zone.
- Add regression coverage for local ISO-8601 date-time strings.

## Testing

- `swift test --filter CompareTests` (fails to build in this environment because UIKit is unavailable)