### PR TITLE
Preserve raw regex condition patterns

### DIFF
--- a/Sources/Nubrick/Data/extraction/extraction.swift
+++ b/Sources/Nubrick/Data/extraction/extraction.swift
@@ -166,7 +166,11 @@ private func isInDistributionSync(distribution: [ExperimentCondition], propertie
 }
 
 func comparePropWithConditionValue(prop: UserProperty, asType: UserPropertyType?, value: String, op: ConditionOperator) -> Bool {
-    let values = value.split(separator: ",", omittingEmptySubsequences: false)
+    // Regex conditions are a single raw pattern, so commas are meaningful pattern
+    // characters rather than list delimiters.
+    let values: [Substring] = op == .Regex
+        ? [Substring(value)]
+        : value.split(separator: ",", omittingEmptySubsequences: false)
     let propType = asType ?? prop.type
     switch propType {
     case .INTEGER:

--- a/Tests/NubrickTests/Data/extraction/extractionTests.swift
+++ b/Tests/NubrickTests/Data/extraction/extractionTests.swift
@@ -645,6 +645,36 @@ final class CompareTests: XCTestCase {
         XCTAssertTrue(compareString(a: "hello-world_11", b: ["[a-zA-Z0-9-_]+"], op: .Regex))
         XCTAssertFalse(compareString(a: "hello", b: ["[^a-zA-Z-_]"], op: .Regex))
     }
+
+    func testCompareStringConditionValuePreservesWhitespace() throws {
+        let prop = UserProperty(name: "color", value: " red ", type: .STRING)
+
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop, asType: nil, value: " red ", op: .Equal
+        ))
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop, asType: nil, value: "blue, red ", op: .In
+        ))
+        XCTAssertFalse(comparePropWithConditionValue(
+            prop: prop, asType: nil, value: "red", op: .Equal
+        ))
+    }
+
+    func testCompareStringRegexConditionPreservesCommas() throws {
+        let prop = UserProperty(name: "coordinate", value: "12,34", type: .STRING)
+
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop, asType: nil, value: "^\\d+,\\d+$", op: .Regex
+        ))
+    }
+
+    func testCompareStringRegexConditionPreservesWhitespace() throws {
+        let prop = UserProperty(name: "greeting", value: " hello", type: .STRING)
+
+        XCTAssertTrue(comparePropWithConditionValue(
+            prop: prop, asType: nil, value: " hello", op: .Regex
+        ))
+    }
     
     func testCompareStringWithRegexShouldBeFalseWhenThePatternIsWrong() throws {
         XCTAssertFalse(compareString(a: "+", b: ["+"], op: .Regex))


### PR DESCRIPTION
## Summary

- Treat regex conditions as a single raw pattern so commas and whitespace are preserved.
- Preserve exact whitespace semantics for non-regex string conditions.
- Add comparison regression coverage.