### PR TITLE
fix: guard webview modal against non-http(s) schemes

### DIFF
--- a/Sources/Nubrick/Component/renderer/modal-component.swift
+++ b/Sources/Nubrick/Component/renderer/modal-component.swift
@@ -11,7 +11,10 @@ import SwiftUI
 import SafariServices
 
 /// How a WEBVIEW_MODAL URL should be handled.
-/// `SFSafariViewController` only accepts http/https; other schemes must not be passed to it.
+///
+/// Goal of this resolver: never pass a non-http(s) URL to `SFSafariViewController`
+/// (that crashes). WEBVIEW_MODAL is for web pages, so http/https → Safari VC is the
+/// supported path; other schemes are best-effort only.
 enum WebviewModalURLAction: Equatable {
     case presentInSafari(URL)
     case openExternally(URL)
@@ -41,7 +44,15 @@ class ModalComponentViewController: UIViewController {
         case .ignore:
             return
         case .openExternally(let urlObj):
-            // Deep-link style: open outside Safari VC (mailto/tel/custom schemes).
+            // Best-effort fallback so non-http(s) never reach SFSafariViewController.
+            // Matches `openLink` in sdk.swift: canOpenURL then open.
+            //
+            // Note: canOpenURL returns false for third-party schemes not listed in the
+            // host app's LSApplicationQueriesSchemes. As an SDK we cannot set that
+            // Info.plist key, so custom schemes (e.g. myapp://) may no-op here.
+            // That is acceptable for WEBVIEW_MODAL — the supported case is http(s).
+            // Do not switch to open-without-canOpenURL just to paper over QueriesSchemes;
+            // broader deep-link open policy would be a separate change.
             guard UIApplication.shared.canOpenURL(urlObj) else {
                 return
             }

--- a/Sources/Nubrick/Component/renderer/modal-component.swift
+++ b/Sources/Nubrick/Component/renderer/modal-component.swift
@@ -10,35 +10,62 @@ import UIKit
 import SwiftUI
 import SafariServices
 
+/// How a WEBVIEW_MODAL URL should be handled.
+/// `SFSafariViewController` only accepts http/https; other schemes must not be passed to it.
+enum WebviewModalURLAction: Equatable {
+    case presentInSafari(URL)
+    case openExternally(URL)
+    case ignore
+}
+
+func resolveWebviewModalURLAction(_ urlString: String?) -> WebviewModalURLAction {
+    guard let urlString = urlString,
+          let url = URL(string: urlString),
+          let scheme = url.scheme?.lowercased(),
+          !scheme.isEmpty else {
+        return .ignore
+    }
+    if scheme == "http" || scheme == "https" {
+        return .presentInSafari(url)
+    }
+    return .openExternally(url)
+}
+
 // vc for navigation view
 class ModalComponentViewController: UIViewController {
     private var currentModal: NavigationViewControlller? = nil
     private var backButtonBehaviorDelegate: ModalBackButtonBehaviorDelegate? = nil
 
     func presentWebview(url: String?, backButtonBehaviorDelegate: ModalBackButtonBehaviorDelegate?) {
-        guard let url = url else {
+        switch resolveWebviewModalURLAction(url) {
+        case .ignore:
             return
-        }
-        guard let urlObj = URL(string: url) else {
-            return
-        }
-        let safariVC = SFSafariViewController(url: urlObj)
-        if let backButtonBehaviorDelegate = backButtonBehaviorDelegate {
-            // keep the instance, because it will be deallocated after the function call.
-            self.backButtonBehaviorDelegate = backButtonBehaviorDelegate
-            safariVC.delegate = self.backButtonBehaviorDelegate
-        }
-        if let modal = self.currentModal {
-            if !isPresenting(presented: self.presentedViewController, vc: modal) {
-                self.currentModal?.dismiss(animated: false)
-                self.currentModal = nil
+        case .openExternally(let urlObj):
+            // Deep-link style: open outside Safari VC (mailto/tel/custom schemes).
+            guard UIApplication.shared.canOpenURL(urlObj) else {
+                return
             }
-        }
+            UIApplication.shared.open(urlObj)
+            return
+        case .presentInSafari(let urlObj):
+            let safariVC = SFSafariViewController(url: urlObj)
+            if let backButtonBehaviorDelegate = backButtonBehaviorDelegate {
+                // keep the instance, because it will be deallocated after the function call.
+                self.backButtonBehaviorDelegate = backButtonBehaviorDelegate
+                safariVC.delegate = self.backButtonBehaviorDelegate
+            }
+            if let modal = self.currentModal {
+                if !isPresenting(presented: self.presentedViewController, vc: modal) {
+                    self.currentModal?.dismiss(animated: false)
+                    self.currentModal = nil
+                }
+            }
 
-        if let modal = self.currentModal {
-            modal.present(safariVC, animated: true)
-        } else {
-            self.presentToTop(safariVC)
+            if let modal = self.currentModal {
+                modal.present(safariVC, animated: true)
+            } else {
+                self.presentToTop(safariVC)
+            }
         }
     }
 

--- a/Tests/NubrickTests/Component/webview-modal-url.swift
+++ b/Tests/NubrickTests/Component/webview-modal-url.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import NubrickLocal
+
+final class WebviewModalURLActionTests: XCTestCase {
+    func testHttpAndHttpsPresentInSafari() {
+        XCTAssertEqual(
+            resolveWebviewModalURLAction("https://example.com/path"),
+            .presentInSafari(URL(string: "https://example.com/path")!)
+        )
+        XCTAssertEqual(
+            resolveWebviewModalURLAction("http://example.com"),
+            .presentInSafari(URL(string: "http://example.com")!)
+        )
+        XCTAssertEqual(
+            resolveWebviewModalURLAction("HTTPS://EXAMPLE.COM"),
+            .presentInSafari(URL(string: "HTTPS://EXAMPLE.COM")!)
+        )
+    }
+
+    func testNonHttpSchemesOpenExternally() {
+        XCTAssertEqual(
+            resolveWebviewModalURLAction("mailto:test@example.com"),
+            .openExternally(URL(string: "mailto:test@example.com")!)
+        )
+        XCTAssertEqual(
+            resolveWebviewModalURLAction("tel:1234567890"),
+            .openExternally(URL(string: "tel:1234567890")!)
+        )
+        XCTAssertEqual(
+            resolveWebviewModalURLAction("myapp://deeplink"),
+            .openExternally(URL(string: "myapp://deeplink")!)
+        )
+    }
+
+    func testInvalidOrEmptyUrlsAreIgnored() {
+        XCTAssertEqual(resolveWebviewModalURLAction(nil), .ignore)
+        XCTAssertEqual(resolveWebviewModalURLAction(""), .ignore)
+        XCTAssertEqual(resolveWebviewModalURLAction("not a url"), .ignore)
+    }
+}


### PR DESCRIPTION
## Summary
- Prevent `SFSafariViewController` from being initialized with non-`http`/`https` URLs in `WEBVIEW_MODAL` (avoids host crash).
- Open other schemes via `UIApplication.shared.open` (deep-link style) when `canOpenURL` allows it.
- Add unit tests for URL action resolution.

Fixes https://github.com/plaidev/nativebrik/issues/2561

## Test plan
- [x] `WebviewModalURLActionTests` on iOS Simulator (`iPhone 17`)
- [ ] Deliver a `WEBVIEW_MODAL` with `https://…` → Safari View Controller presents
- [ ] Deliver a `WEBVIEW_MODAL` with `mailto:` / `tel:` / custom scheme → app does not crash; opens externally when allowed
- [ ] Invalid / empty URL → no-op (no crash)


Made with [Cursor](https://cursor.com)