### PR TITLE
Use local calendar days for retention

### DIFF
--- a/Sources/Nubrick/Data/user.swift
+++ b/Sources/Nubrick/Data/user.swift
@@ -56,6 +56,12 @@ private let USER_CUSTOM_PROPERTY_KEY_PREFIX = "NATIVEBRIK_CUSTOM_"
 private let USER_SEED_KEY: String = "NATIVEBRIK_USER_SEED"
 private let USER_SEED_MAX: Int = 100000000
 
+func retentionCalendarDayDifference(from earlier: Date, to later: Date, calendar: Calendar = .current) -> Int? {
+    let earlierDay = calendar.startOfDay(for: earlier)
+    let laterDay = calendar.startOfDay(for: later)
+    return calendar.dateComponents([.day], from: earlierDay, to: laterDay).day
+}
+
 private func formatUserPropertyValue(_ value: Any) -> String {
     if let date = value as? Date {
         return date.ISO8601Format()
@@ -198,24 +204,23 @@ class NubrickUser {
         self.properties[BuiltinUserProperty.lastBootTime.rawValue] = lastBootTime.ISO8601Format()
         self.lastBootTime = lastBootTime.timeIntervalSince1970
 
-        let retentionTimestamp = self.userDB.object(forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_T.rawValue) as? Int ?? Int(now.timeIntervalSince1970)
+        let storedRetentionTimestamp = self.userDB.object(forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_T.rawValue) as? Int
+        let retentionTimestamp = storedRetentionTimestamp ?? Int(now.timeIntervalSince1970)
         let retentionCount = self.userDB.object(forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_COUNT.rawValue) as? Int ?? 0
         self.properties[BuiltinUserProperty.retentionPeriod.rawValue] = String(retentionCount)
 
-        // 1 day is equal to 86400 seconds
-        let lastDaysSince1970 = Int(retentionTimestamp / (86400))
-        let daysSince1970 = Int(now.timeIntervalSince1970 / (86400))
-        if lastDaysSince1970 == daysSince1970 - 1 {
+        let previousRetentionDate = Date(timeIntervalSince1970: TimeInterval(retentionTimestamp))
+        let dayDifference = retentionCalendarDayDifference(from: previousRetentionDate, to: now) ?? 0
+        if storedRetentionTimestamp == nil {
+            self.userDB.set(retentionTimestamp, forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_T.rawValue)
+            self.userDB.set(retentionCount, forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_COUNT.rawValue)
+        } else if dayDifference == 1 {
             // count up retention. because user is returned in 1 day
             self.userDB.set(Int(now.timeIntervalSince1970), forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_T.rawValue)
             let countedUp = retentionCount + 1
             self.userDB.set(countedUp, forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_COUNT.rawValue)
             self.properties[BuiltinUserProperty.retentionPeriod.rawValue] = String(countedUp)
-        } else if lastDaysSince1970 == daysSince1970 {
-            // save the initial count
-            self.userDB.set(retentionTimestamp, forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_T.rawValue)
-            self.userDB.set(retentionCount, forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_COUNT.rawValue)
-        } else if lastDaysSince1970 < daysSince1970 - 1 {
+        } else if dayDifference > 1 {
             // reset retention. because user won't be returned in 1 day
             self.userDB.set(Int(now.timeIntervalSince1970), forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_T.rawValue)
             let reseted = 0

--- a/Tests/NubrickTests/Data/user.swift
+++ b/Tests/NubrickTests/Data/user.swift
@@ -10,6 +10,68 @@ import XCTest
 
 @MainActor
 final class UserTests: XCTestCase {
+    func testComeBackInitializesRetentionTimestamp() throws {
+        let suiteName = "NubrickTests.\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let user = NubrickUser()
+        user.userDB = userDefaults
+        user.comeBack()
+
+        XCTAssertNotNil(userDefaults.object(forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_T.rawValue))
+        XCTAssertEqual(
+            userDefaults.object(forKey: NativebrikUserDefaultsKeys.RETENTION_PERIOD_COUNT.rawValue) as? Int,
+            0
+        )
+    }
+
+    func testRetentionUsesLocalCalendarDaysRatherThanUTCDays() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "Asia/Tokyo"))
+
+        let sameLocalDayBeforeUTCMidnight = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026, month: 8, day: 13, hour: 8, minute: 55
+        )))
+        let sameLocalDayAfterUTCMidnight = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026, month: 8, day: 13, hour: 9, minute: 5
+        )))
+        let nextLocalDay = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026, month: 8, day: 14, hour: 0, minute: 30
+        )))
+
+        XCTAssertEqual(
+            retentionCalendarDayDifference(
+                from: sameLocalDayBeforeUTCMidnight,
+                to: sameLocalDayAfterUTCMidnight,
+                calendar: calendar
+            ),
+            0
+        )
+        XCTAssertEqual(
+            retentionCalendarDayDifference(
+                from: sameLocalDayAfterUTCMidnight,
+                to: nextLocalDay,
+                calendar: calendar
+            ),
+            1
+        )
+    }
+
+    func testRetentionCalendarDayDifferenceHandlesDSTTransition() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "America/Los_Angeles"))
+
+        let beforeDST = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026, month: 3, day: 8, hour: 0, minute: 30
+        )))
+        let afterDST = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026, month: 3, day: 9, hour: 0, minute: 30
+        )))
+
+        XCTAssertEqual(retentionCalendarDayDifference(from: beforeDST, to: afterDST, calendar: calendar), 1)
+    }
+
     func testHasUserIdByDefaultAndAlwaysTheSame() {
         let user = NubrickUser()
         let userId = user.id


### PR DESCRIPTION
## Summary

- calculate retention using local calendar-day boundaries
- initialize missing retention state explicitly
- cover timezone and DST day comparisons