### PR TITLE
feat: persist tracking events in an outbox

### DIFF
--- a/Sources/Nubrick/Data/database/helper.swift
+++ b/Sources/Nubrick/Data/database/helper.swift
@@ -68,20 +68,70 @@ final class UserEventEntity: NSManagedObject {
     }
 }
 
+final class PendingTrackEventEntity: NSManagedObject {
+    @NSManaged var eventID: String
+    @NSManaged var payload: Data
+    @NSManaged var eventType: String
+    @NSManaged var byteCount: Int64
+    @NSManaged var createdAt: Date
+
+    static func entityDescription() -> NSEntityDescription {
+        let entity = NSEntityDescription()
+        entity.name = "NativebrikPendingTrackEvent"
+        entity.managedObjectClassName = NSStringFromClass(PendingTrackEventEntity.self)
+
+        let eventID = NSAttributeDescription()
+        eventID.name = "eventID"
+        eventID.attributeType = .stringAttributeType
+        eventID.isOptional = false
+
+        let payload = NSAttributeDescription()
+        payload.name = "payload"
+        payload.attributeType = .binaryDataAttributeType
+        payload.isOptional = false
+
+        let eventType = NSAttributeDescription()
+        eventType.name = "eventType"
+        eventType.attributeType = .stringAttributeType
+        eventType.isOptional = false
+
+        let byteCount = NSAttributeDescription()
+        byteCount.name = "byteCount"
+        byteCount.attributeType = .integer64AttributeType
+        byteCount.isOptional = false
+
+        let createdAt = NSAttributeDescription()
+        createdAt.name = "createdAt"
+        createdAt.attributeType = .dateAttributeType
+        createdAt.isOptional = false
+
+        entity.properties = [eventID, payload, eventType, byteCount, createdAt]
+        return entity
+    }
+}
+
 @MainActor
 private let nativebrikManagedObjectModel: NSManagedObjectModel = {
     let model = NSManagedObjectModel()
     model.entities = [
         UserEventEntity.entityDescription(),
         ExperimentHistoryEntity.entityDescription(),
+        PendingTrackEventEntity.entityDescription(),
     ]
     return model
 }()
 
 @MainActor
-func createNativebrikCoreDataHelper() -> NSPersistentContainer? {
+func createNativebrikCoreDataHelper(storeURL: URL? = nil) -> NSPersistentContainer? {
     let container = NSPersistentContainer(name: "com.nativebrik.sdk", managedObjectModel: nativebrikManagedObjectModel)
-    container.persistentStoreDescriptions.first?.shouldAddStoreAsynchronously = false
+    if let description = container.persistentStoreDescriptions.first {
+        if let storeURL {
+            description.url = storeURL
+        }
+        description.shouldAddStoreAsynchronously = false
+        description.shouldMigrateStoreAutomatically = true
+        description.shouldInferMappingModelAutomatically = true
+    }
 
     var loadError: Error?
     container.loadPersistentStores { _, error in

--- a/Sources/Nubrick/Data/dependency-container.swift
+++ b/Sources/Nubrick/Data/dependency-container.swift
@@ -27,7 +27,12 @@ struct NubrickDependencyContainer : Sendable {
         self.user = user
         self.experimentRepository = ExperimentRepositoryImpl(config: config)
         self.componentRepository = ComponentRepositoryImpl(config: config)
-        self.trackRepository = TrackRespositoryImpl(config: config, user: user)
+        let trackRepository = TrackRespositoryImpl(
+            config: config,
+            user: user,
+            persistentContainer: persistentContainer
+        )
+        self.trackRepository = trackRepository
         self.databaseRepository = DatabaseRepositoryImpl(persistentContainer: persistentContainer)
         self.httpRequestRepository = HttpRequestRepositoryImpl(intercepter: httpRequestInterceptor)
         self.actionHandler = actionHandler

--- a/Sources/Nubrick/Data/network.swift
+++ b/Sources/Nubrick/Data/network.swift
@@ -62,6 +62,29 @@ let nativebrikSession: URLSession = {
     return URLSession(configuration: sessionConfig)
 }()
 
+/// Tracking has an independent, longer deadline so a slow acknowledgement does
+/// not cause analytics batches to be discarded with the SDK's other requests.
+let trackingSession: URLSession = {
+    let sessionConfig = URLSessionConfiguration.default
+    sessionConfig.waitsForConnectivity = true
+    sessionConfig.allowsCellularAccess = true
+    sessionConfig.allowsExpensiveNetworkAccess = true
+    sessionConfig.allowsConstrainedNetworkAccess = true
+    sessionConfig.timeoutIntervalForRequest = 30.0
+    sessionConfig.timeoutIntervalForResource = 30.0
+    return URLSession(configuration: sessionConfig)
+}()
+
+protocol TrackingHTTPClient: Sendable {
+    func fetchData(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: TrackingHTTPClient {
+    func fetchData(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await data(for: request)
+    }
+}
+
 func invalidateCachedResponse(for request: URLRequest) {
     if let url = request.url {
         MemoryResponseCache.shared.remove(url)

--- a/Sources/Nubrick/Data/track.swift
+++ b/Sources/Nubrick/Data/track.swift
@@ -8,8 +8,13 @@
 import Foundation
 import UIKit
 import Darwin.Mach
+import CoreData
 
 private let CRASH_RECORD_KEY: String = "NATIVEBRIK_CRASH_RECORD"
+
+private func trackWarn(_ message: String) {
+    print("[Nubrick] \(message)")
+}
 
 // Convert MetricKit exception type to string after copying the raw value out of the diagnostic.
 func exceptionTypeString(_ raw: UInt32?) -> String {
@@ -54,7 +59,7 @@ private struct RawFrame: Decodable {
 }
 
 @_spi(FlutterBridge)
-public struct StackFrame: Encodable, Sendable {
+public struct StackFrame: Codable, Sendable {
     // iOS fields
     public let imageAddr: String?
     public let instructionAddr: String?
@@ -89,7 +94,7 @@ public struct StackFrame: Encodable, Sendable {
 }
 
 @_spi(FlutterBridge)
-public struct ExceptionRecord: Encodable, Sendable {
+public struct ExceptionRecord: Codable, Sendable {
     public let type: String?
     public let message: String?
     public let callStacks: [StackFrame]?
@@ -148,6 +153,7 @@ public enum CrashSeverity: String, Sendable {
 protocol TrackRepository2 : Actor {
     func trackExperimentEvent(_ event: TrackExperimentEvent)
     func trackEvent(_ event: TrackUserEvent)
+    func flushNow() async
 
     func processMetricKitCrash(
         callStackTreeJSON: Data,
@@ -177,8 +183,8 @@ struct TrackRequest: Encodable {
     var meta: TrackEventMeta
 }
 
-struct TrackEvent: Encodable {
-    enum Typename: String, Encodable {
+struct TrackEvent: Codable {
+    enum Typename: String, Codable {
         case Event = "event"
         case Experiment = "experiment"
         case Crash = "crash"
@@ -193,10 +199,11 @@ struct TrackEvent: Encodable {
     var platform: String?
     var flutterSdkVersion: String?
     var severity: String?
+    var eventUuid: String
 }
 
 @_spi(FlutterBridge)
-public struct ThreadRecord: Encodable, Sendable {
+public struct ThreadRecord: Codable, Sendable {
     /// For MetricKit crashes, this is the crash-attributed thread. The JSON
     /// field name is retained for backend compatibility.
     public let isMain: Bool?
@@ -274,20 +281,240 @@ func imageAddrHex(addressDec: UInt64, offsetIntoTextDec: UInt64) -> String? {
 }
 
 
+/// Outbox retries only help for transient failures. 4xx other than 408/429 will
+/// not succeed on a later attempt, so those records should be dropped.
+func isRetryableTrackingStatusCode(_ statusCode: Int) -> Bool {
+    statusCode >= 500 || statusCode == 408 || statusCode == 429
+}
+
+struct PendingTrackEvent {
+    let eventID: String
+    let event: TrackEvent
+    let payloadSize: Int
+}
+
+struct TrackOutboxLimits: Sendable {
+    let maxQueueSize: Int
+    let maxQueueBytes: Int
+    let maxEventPayloadBytes: Int
+
+    init(
+        maxQueueSize: Int = 5_000,
+        maxQueueBytes: Int = 10 * 1024 * 1024,
+        maxEventPayloadBytes: Int = 500 * 1024
+    ) {
+        self.maxQueueSize = maxQueueSize
+        self.maxQueueBytes = maxQueueBytes
+        self.maxEventPayloadBytes = maxEventPayloadBytes
+    }
+}
+
+final class TrackOutbox {
+    private let persistentContainer: NSPersistentContainer
+    private let limits: TrackOutboxLimits
+
+    init(
+        persistentContainer: NSPersistentContainer,
+        limits: TrackOutboxLimits = TrackOutboxLimits()
+    ) {
+        self.persistentContainer = persistentContainer
+        self.limits = limits
+    }
+
+    func insert(_ event: TrackEvent, enqueuedAt: Date = getCurrentDate()) -> Int? {
+        guard let payload = try? JSONEncoder().encode(event) else {
+            trackWarn("Dropping tracking event because it could not be persisted.")
+            return nil
+        }
+        guard payload.count <= limits.maxEventPayloadBytes else {
+            trackWarn("Dropping oversized tracking event.")
+            return nil
+        }
+
+        let context = persistentContainer.newBackgroundContext()
+        let limits = limits
+        let eventID = event.eventUuid
+        let eventType = event.typename
+        return context.performAndWait {
+            do {
+                try Self.enforceLimits(in: context, limits: limits, incomingByteCount: payload.count)
+
+                let entity = PendingTrackEventEntity(context: context)
+                entity.eventID = eventID
+                entity.payload = payload
+                entity.eventType = eventType.rawValue
+                entity.byteCount = Int64(payload.count)
+                entity.createdAt = enqueuedAt
+                try context.save()
+
+                guard eventType != .Crash else {
+                    return 0
+                }
+                let request = NSFetchRequest<PendingTrackEventEntity>(entityName: "NativebrikPendingTrackEvent")
+                request.predicate = NSPredicate(format: "eventType != %@", TrackEvent.Typename.Crash.rawValue)
+                return try context.count(for: request)
+            } catch {
+                context.rollback()
+                trackWarn("Dropping tracking event because the outbox could not be saved: \(error)")
+                return nil
+            }
+        }
+    }
+
+    func nextCrash() throws -> PendingTrackEvent? {
+        try fetch(eventType: TrackEvent.Typename.Crash.rawValue, limit: 1).first
+    }
+
+    func nextNormalBatch(maxEvents: Int, maxPayloadBytes: Int) throws -> [PendingTrackEvent] {
+        let entries = try fetch(excludingEventType: TrackEvent.Typename.Crash.rawValue, limit: maxEvents)
+        var batch = [PendingTrackEvent]()
+        var payloadBytes = 0
+        for entry in entries {
+            if !batch.isEmpty && payloadBytes + entry.payloadSize > maxPayloadBytes {
+                break
+            }
+            batch.append(entry)
+            payloadBytes += entry.payloadSize
+        }
+        return batch
+    }
+
+    func remove(eventIDs: [String]) -> Bool {
+        guard !eventIDs.isEmpty else { return true }
+        let context = persistentContainer.newBackgroundContext()
+        return context.performAndWait {
+            let request = NSFetchRequest<PendingTrackEventEntity>(entityName: "NativebrikPendingTrackEvent")
+            request.predicate = NSPredicate(format: "eventID IN %@", eventIDs)
+            do {
+                for entity in try context.fetch(request) {
+                    context.delete(entity)
+                }
+                try context.save()
+                return true
+            } catch {
+                context.rollback()
+                trackWarn("Could not remove delivered tracking events from the outbox: \(error)")
+                return false
+            }
+        }
+    }
+
+    func hasPendingEvents() throws -> Bool {
+        let context = persistentContainer.newBackgroundContext()
+        return try context.performAndWait {
+            let request = NSFetchRequest<PendingTrackEventEntity>(entityName: "NativebrikPendingTrackEvent")
+            request.fetchLimit = 1
+            return try context.count(for: request) > 0
+        }
+    }
+
+    private func fetch(eventType: String? = nil, excludingEventType: String? = nil, limit: Int) throws -> [PendingTrackEvent] {
+        let context = persistentContainer.newBackgroundContext()
+        return try context.performAndWait {
+            let request = NSFetchRequest<PendingTrackEventEntity>(entityName: "NativebrikPendingTrackEvent")
+            if let eventType {
+                request.predicate = NSPredicate(format: "eventType == %@", eventType)
+            } else if let excludingEventType {
+                request.predicate = NSPredicate(format: "eventType != %@", excludingEventType)
+            }
+            request.fetchLimit = limit
+            request.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: true)]
+            do {
+                var pending = [PendingTrackEvent]()
+                for entity in try context.fetch(request) {
+                    guard let event = try? JSONDecoder().decode(TrackEvent.self, from: entity.payload) else {
+                        context.delete(entity)
+                        trackWarn("Dropping corrupt tracking event from the outbox.")
+                        continue
+                    }
+                    pending.append(PendingTrackEvent(
+                        eventID: entity.eventID,
+                        event: event,
+                        payloadSize: Int(entity.byteCount)
+                    ))
+                }
+                if context.hasChanges {
+                    try context.save()
+                }
+                return pending
+            } catch {
+                context.rollback()
+                trackWarn("Could not read tracking events from the outbox: \(error)")
+                throw error
+            }
+        }
+    }
+
+    private static func enforceLimits(
+        in context: NSManagedObjectContext,
+        limits: TrackOutboxLimits,
+        incomingByteCount: Int
+    ) throws {
+        let request = NSFetchRequest<PendingTrackEventEntity>(entityName: "NativebrikPendingTrackEvent")
+        var totalCount = try context.count(for: request)
+        var totalBytes = try totalPendingBytes(in: context)
+        var didEvict = false
+
+        let oldestRequest = NSFetchRequest<PendingTrackEventEntity>(entityName: "NativebrikPendingTrackEvent")
+        oldestRequest.fetchLimit = 1
+        oldestRequest.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: true)]
+        while totalCount + 1 > limits.maxQueueSize || totalBytes + incomingByteCount > limits.maxQueueBytes {
+            guard let entry = try context.fetch(oldestRequest).first else {
+                break
+            }
+            totalCount -= 1
+            totalBytes -= Int(entry.byteCount)
+            context.delete(entry)
+            didEvict = true
+        }
+        if didEvict {
+            trackWarn("Discarded oldest pending tracking events because the outbox limit was reached.")
+        }
+    }
+
+    private static func totalPendingBytes(in context: NSManagedObjectContext) throws -> Int {
+        let totalByteCount = NSExpressionDescription()
+        totalByteCount.name = "totalByteCount"
+        totalByteCount.expression = NSExpression(
+            forFunction: "sum:",
+            arguments: [NSExpression(forKeyPath: "byteCount")]
+        )
+        totalByteCount.expressionResultType = .integer64AttributeType
+
+        let request = NSFetchRequest<NSDictionary>(entityName: "NativebrikPendingTrackEvent")
+        request.resultType = .dictionaryResultType
+        request.propertiesToFetch = [totalByteCount]
+        let result = try context.fetch(request)
+        let byteCount = result.first?[totalByteCount.name] as? NSNumber
+        return byteCount.map { Int($0.int64Value) } ?? 0
+    }
+}
+
 actor TrackRespositoryImpl: TrackRepository2 {
-    private let maxQueueSize: Int
-    private let maxBatchSize: Int
+    private let maxBatchSize = 50
+    private let maxBatchPayloadBytes = 512 * 1024
+    private let maxBatchEventPayloadBytes = 500 * 1024
+    private let flushInterval: TimeInterval = 10
     private let config: Config
     private let user: NubrickUser
+    private let outbox: TrackOutbox
+    private let trackingHTTPClient: any TrackingHTTPClient
     private var flushTask: Task<Void, Never>?
-    private var buffer: [TrackEvent]
-    init(config: Config, user: NubrickUser) {
-        self.maxQueueSize = 300
-        self.maxBatchSize = 50
+    private var scheduledFlushID: UUID?
+    private var isSending = false
+    private var drainWaiters: [CheckedContinuation<Void, Never>] = []
+    private var retryDelay: TimeInterval = 10
+
+    init(
+        config: Config,
+        user: NubrickUser,
+        persistentContainer: NSPersistentContainer,
+        trackingHTTPClient: any TrackingHTTPClient = trackingSession
+    ) {
         self.config = config
         self.user = user
-        self.buffer = []
-        self.flushTask = nil
+        self.outbox = TrackOutbox(persistentContainer: persistentContainer)
+        self.trackingHTTPClient = trackingHTTPClient
     }
 
     private func makeJsonRequest<Body: Encodable>(
@@ -302,79 +529,161 @@ actor TrackRespositoryImpl: TrackRepository2 {
     }
 
     func trackExperimentEvent(_ event: TrackExperimentEvent) {
-        self.pushToQueue(TrackEvent(
+        enqueue(TrackEvent(
             typename: .Experiment,
             experimentId: event.experimentId,
             variantId: event.variantId,
-            timestamp: getCurrentDate().ISO8601Format()
+            timestamp: getCurrentDate().ISO8601Format(),
+            eventUuid: UUID().uuidString
         ))
     }
     
     func trackEvent(_ event: TrackUserEvent) {
-        self.pushToQueue(TrackEvent(
+        enqueue(TrackEvent(
             typename: .Event,
             name: event.name,
-            timestamp: getCurrentDate().ISO8601Format()
+            timestamp: getCurrentDate().ISO8601Format(),
+            eventUuid: UUID().uuidString
         ))
     }
-    
-    private func scheduleFlushTaskIfNeeded() {
-        guard self.flushTask == nil else {return }
-        self.flushTask = Task {
-            defer {
-                self.flushTask = nil
-                if !self.buffer.isEmpty {
-                    self.scheduleFlushTaskIfNeeded()
+
+    func flushNow() async {
+        flushTask?.cancel()
+        flushTask = nil
+        scheduledFlushID = nil
+        await drainOutbox()
+    }
+
+    private func enqueue(_ event: TrackEvent) {
+        guard let pendingNormalEventCount = outbox.insert(event) else { return }
+        if event.typename == .Crash || pendingNormalEventCount >= maxBatchSize {
+            requestFlush(after: 0)
+        } else {
+            requestFlush(after: flushInterval)
+        }
+    }
+
+    private func requestFlush(after delay: TimeInterval) {
+        guard !isSending else { return }
+        if flushTask != nil {
+            guard delay == 0 else { return }
+            flushTask?.cancel()
+            flushTask = nil
+            scheduledFlushID = nil
+        }
+        let flushID = UUID()
+        scheduledFlushID = flushID
+        flushTask = Task { [weak self] in
+            guard let self else { return }
+            if delay > 0 {
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                } catch {
+                    return
                 }
             }
-            do {
-                try await Task.sleep(nanoseconds: 4 * 1_000_000_000)
-            } catch {
-                return
-            }
-            await self.sendAndFlush()
+            guard !Task.isCancelled else { return }
+            await self.runScheduledFlush(id: flushID)
         }
     }
-    
-    private func pushToQueue(_ event: TrackEvent) {
-        scheduleFlushTaskIfNeeded()
 
-        if self.buffer.count >= self.maxBatchSize {
-            Task(priority: .low) {
-                await self.sendAndFlush()
-            }
-        }
-        self.buffer.append(event)
-        if self.buffer.count > self.maxQueueSize {
-            let overflow = self.buffer.count - self.maxQueueSize
-            self.buffer.removeFirst(overflow)
-        }
-        
+    private func runScheduledFlush(id: UUID) async {
+        guard scheduledFlushID == id else { return }
+        flushTask = nil
+        scheduledFlushID = nil
+        await drainOutbox()
     }
-    
-    private func sendAndFlush() async {
-        guard self.buffer.count > 0 else { return }
 
-        let events = self.buffer
-        self.buffer = []
-
-        let userID = await MainActor.run {
-            self.user.id
+    private func drainOutbox() async {
+        if isSending {
+            await withCheckedContinuation { continuation in
+                drainWaiters.append(continuation)
+            }
+            return
         }
-        let trackRequest = TrackRequest(
-            projectId: self.config.projectId,
-            userId: userID,
-            timestamp: getCurrentDate().ISO8601Format(),
-            events: events,
-            meta: await TrackEventMeta.current()
-        )
+
+        isSending = true
+        var retryAfter: TimeInterval?
 
         do {
-            let url = URL(string: config.trackUrl)!
-            let request = try makeJsonRequest(url: url, body: trackRequest)
-            let _ = try await nativebrikSession.data(for: request)
+            while try outbox.hasPendingEvents() {
+                if try await sendNextBatch() {
+                    retryDelay = 10
+                    continue
+                }
+
+                let delay = retryDelay
+                retryDelay = min(retryDelay * 2, 5 * 60)
+                retryAfter = delay
+                break
+            }
         } catch {
-            self.buffer.append(contentsOf: events)
+            trackWarn("Could not drain the tracking outbox: \(error)")
+            let delay = retryDelay
+            retryDelay = min(retryDelay * 2, 5 * 60)
+            retryAfter = delay
+        }
+
+        isSending = false
+        let waiters = drainWaiters
+        drainWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+
+        if let retryAfter {
+            requestFlush(after: retryAfter)
+        }
+    }
+
+    private func sendNextBatch() async throws -> Bool {
+        let pending: [PendingTrackEvent]
+        if let crash = try outbox.nextCrash() {
+            pending = [crash]
+        } else {
+            pending = try outbox.nextNormalBatch(maxEvents: maxBatchSize, maxPayloadBytes: maxBatchEventPayloadBytes)
+        }
+        guard !pending.isEmpty else { return true }
+
+        do {
+            let userID = await MainActor.run { self.user.id }
+            let meta = await TrackEventMeta.current()
+            var batch = pending
+
+            while !batch.isEmpty {
+                let trackRequest = TrackRequest(
+                    projectId: config.projectId,
+                    userId: userID,
+                    timestamp: getCurrentDate().ISO8601Format(),
+                    events: batch.map(\.event),
+                    meta: meta
+                )
+                let url = URL(string: config.trackUrl)!
+                let request = try makeJsonRequest(url: url, body: trackRequest)
+                if request.httpBody?.count ?? 0 <= maxBatchPayloadBytes {
+                    let (_, response) = try await trackingHTTPClient.fetchData(for: request)
+                    guard let response = response as? HTTPURLResponse else {
+                        return false
+                    }
+                    if (200...299).contains(response.statusCode) {
+                        return outbox.remove(eventIDs: batch.map(\.eventID))
+                    }
+                    if isRetryableTrackingStatusCode(response.statusCode) {
+                        return false
+                    }
+                    trackWarn("Dropping tracking batch after a non-retryable HTTP \(response.statusCode) response.")
+                    return outbox.remove(eventIDs: batch.map(\.eventID))
+                }
+
+                guard batch.count > 1 else {
+                    trackWarn("Dropping oversized tracking event.")
+                    return outbox.remove(eventIDs: batch.map(\.eventID))
+                }
+                batch.removeLast()
+            }
+            return true
+        } catch {
+            return false
         }
     }
     
@@ -452,35 +761,34 @@ actor TrackRespositoryImpl: TrackRepository2 {
 
         // Only send error tracking events for error or fatal severity
         if crashEvent.severity.isErrorLevel {
-            self.buffer.append(TrackEvent(
+            enqueue(TrackEvent(
                 typename: .Event,
                 name: TriggerEventNameDefs.N_ERROR_RECORD.rawValue,
                 timestamp: getCurrentDate().ISO8601Format(),
-                platform: nil
+                platform: nil,
+                eventUuid: UUID().uuidString
             ))
         }
         if causedByNativebrik {
             if crashEvent.severity.isErrorLevel {
-                self.buffer.append(TrackEvent(
+                enqueue(TrackEvent(
                     typename: .Event,
                     name: TriggerEventNameDefs.N_ERROR_IN_SDK_RECORD.rawValue,
                     timestamp: getCurrentDate().ISO8601Format(),
-                    platform: nil
+                    platform: nil,
+                    eventUuid: UUID().uuidString
                 ))
             }
-            self.buffer.append(TrackEvent(
+            enqueue(TrackEvent(
                 typename: .Crash,
                 timestamp: getCurrentDate().ISO8601Format(),
                 exceptions: crashEvent.exceptions,
                 threads: crashEvent.threads,
                 platform: crashEvent.platform,
                 flutterSdkVersion: crashEvent.flutterSdkVersion,
-                severity: crashEvent.severity.rawValue
+                severity: crashEvent.severity.rawValue,
+                eventUuid: UUID().uuidString
             ))
-        }
-
-        Task(priority: .utility) {
-            await self.sendAndFlush()
         }
     }
 

--- a/Sources/Nubrick/sdk.swift
+++ b/Sources/Nubrick/sdk.swift
@@ -56,6 +56,51 @@ private final class AppMetrics: NSObject, MXMetricManagerSubscriber {
 }
 
 @MainActor
+private final class TrackingLifecycleObserver {
+    private var observers = [NSObjectProtocol]()
+
+    init(trackRepository: TrackRepository2) {
+        let trackRepository = trackRepository
+        let center = NotificationCenter.default
+        observers.append(center.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task {
+                await trackRepository.flushNow()
+            }
+        })
+        observers.append(center.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            // queue: .main delivers this on the main thread. Register the
+            // background task before returning so iOS does not suspend first.
+            MainActor.assumeIsolated {
+                Self.flushInBackground(trackRepository: trackRepository)
+            }
+        })
+    }
+
+    private static func flushInBackground(trackRepository: TrackRepository2) {
+        var taskID = UIBackgroundTaskIdentifier.invalid
+        taskID = UIApplication.shared.beginBackgroundTask(withName: "Nubrick tracking flush") {
+            guard taskID != .invalid else { return }
+            UIApplication.shared.endBackgroundTask(taskID)
+            taskID = .invalid
+        }
+        Task {
+            await trackRepository.flushNow()
+            guard taskID != .invalid else { return }
+            UIApplication.shared.endBackgroundTask(taskID)
+            taskID = .invalid
+        }
+    }
+}
+
+@MainActor
 private func openLink(_ event: ComponentEvent) {
     guard let link = event.deepLink,
           let url = URL(string: link),
@@ -152,6 +197,7 @@ final class NubrickCore {
     private let dependencies: NubrickDependencyContainer
     private let overlayVC: OverlayViewController
     private let bridgeCallbackStore: BridgeCallbackStore
+    private let trackingLifecycleObserver: TrackingLifecycleObserver
 
     init?(
         projectId: String,
@@ -188,12 +234,16 @@ final class NubrickCore {
 
         self.bridgeCallbackStore = bridgeCallbackStore
         self.dependencies = dependencies
+        self.trackingLifecycleObserver = TrackingLifecycleObserver(trackRepository: dependencies.trackRepository)
         self.overlayVC = OverlayViewController(
             user: user,
             container: dependencies.makeContainer(),
             onDispatch: onDispatch,
             onTooltip: onTooltip
         )
+        Task {
+            await dependencies.trackRepository.flushNow()
+        }
     }
 
     func dispatch(_ event: NubrickEvent) {

--- a/Tests/NubrickTests/Data/repository.swift
+++ b/Tests/NubrickTests/Data/repository.swift
@@ -5,6 +5,7 @@
 //  Created by Ryosuke Suzuki on 2023/11/02.
 //
 
+import CoreData
 import Foundation
 
 import XCTest
@@ -25,6 +26,8 @@ private actor SurveyResponseTrackRepositorySpy: TrackRepository2 {
     func trackExperimentEvent(_ event: TrackExperimentEvent) {}
 
     func trackEvent(_ event: TrackUserEvent) {}
+
+    func flushNow() async {}
 
     func processMetricKitCrash(
         callStackTreeJSON: Data,
@@ -57,7 +60,485 @@ private actor SurveyResponseTrackRepositorySpy: TrackRepository2 {
     }
 }
 
+private actor FlushCompletionFlag {
+    private var complete = false
+
+    func markComplete() {
+        complete = true
+    }
+
+    func isComplete() -> Bool {
+        complete
+    }
+}
+
+private actor TrackingHTTPClientSpy: TrackingHTTPClient {
+    enum Response {
+        case statusCode(Int)
+        case failure
+    }
+
+    private var response: Response
+    private var queuedResponses: [Response] = []
+    private var requests = [URLRequest]()
+    private var holdFetches = false
+    private var heldFetch: CheckedContinuation<Void, Never>?
+    private var fetchStartWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(response: Response, holdFetches: Bool = false) {
+        self.response = response
+        self.holdFetches = holdFetches
+    }
+
+    func fetchData(for request: URLRequest) async throws -> (Data, URLResponse) {
+        requests.append(request)
+        if holdFetches {
+            await withCheckedContinuation { continuation in
+                heldFetch = continuation
+                let waiters = fetchStartWaiters
+                fetchStartWaiters.removeAll()
+                for waiter in waiters {
+                    waiter.resume()
+                }
+            }
+        }
+        let response = nextResponse()
+        switch response {
+        case .statusCode(let statusCode):
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: nil
+            ) else {
+                throw URLError(.badURL)
+            }
+            return (Data(), response)
+        case .failure:
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+
+    func setResponse(_ response: Response) {
+        self.response = response
+    }
+
+    func enqueueResponses(_ responses: [Response]) {
+        queuedResponses.append(contentsOf: responses)
+    }
+
+    private func nextResponse() -> Response {
+        guard !queuedResponses.isEmpty else {
+            return response
+        }
+        return queuedResponses.removeFirst()
+    }
+
+    func waitForFetchStart() async {
+        if heldFetch != nil {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            fetchStartWaiters.append(continuation)
+        }
+    }
+
+    func releaseHeldFetch() {
+        let heldFetch = heldFetch
+        self.heldFetch = nil
+        heldFetch?.resume()
+    }
+
+    func recordedRequests() -> [URLRequest] {
+        requests
+    }
+}
+
 final class HttpRequestReposotiryTests: XCTestCase {
+    @MainActor
+    func testTrackingOutboxEvictsOnlyTheOldestEventAtCountLimit() throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let outbox = TrackOutbox(
+            persistentContainer: persistentContainer,
+            limits: TrackOutboxLimits(maxQueueSize: 2, maxQueueBytes: 1_000_000)
+        )
+        let first = makePendingTrackEvent(name: "first")
+        let second = makePendingTrackEvent(name: "second")
+        let third = makePendingTrackEvent(name: "third")
+
+        XCTAssertNotNil(outbox.insert(first, enqueuedAt: Date(timeIntervalSince1970: 1)))
+        XCTAssertNotNil(outbox.insert(second, enqueuedAt: Date(timeIntervalSince1970: 2)))
+        XCTAssertNotNil(outbox.insert(third, enqueuedAt: Date(timeIntervalSince1970: 3)))
+
+        XCTAssertEqual(
+            try pendingTrackEventIDs(in: persistentContainer),
+            [second.eventUuid, third.eventUuid]
+        )
+    }
+
+    @MainActor
+    func testTrackingOutboxEvictsOnlyTheOldestEventAtByteLimit() throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let first = makePendingTrackEvent(name: "first")
+        let second = makePendingTrackEvent(name: "second")
+        let byteLimit = max(
+            try JSONEncoder().encode(first).count,
+            try JSONEncoder().encode(second).count
+        )
+        let outbox = TrackOutbox(
+            persistentContainer: persistentContainer,
+            limits: TrackOutboxLimits(maxQueueSize: 10, maxQueueBytes: byteLimit)
+        )
+
+        XCTAssertNotNil(outbox.insert(first, enqueuedAt: Date(timeIntervalSince1970: 1)))
+        XCTAssertNotNil(outbox.insert(second, enqueuedAt: Date(timeIntervalSince1970: 2)))
+
+        XCTAssertEqual(try pendingTrackEventIDs(in: persistentContainer), [second.eventUuid])
+    }
+
+    @MainActor
+    func testTrackingEventPersistsThenFlushesAfterSuccessfulResponse() async throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let client = TrackingHTTPClientSpy(response: .statusCode(200))
+        let repository = TrackRespositoryImpl(
+            config: Config(projectId: PROJECT_ID_FOR_TEST),
+            user: NubrickUser(),
+            persistentContainer: persistentContainer,
+            trackingHTTPClient: client
+        )
+
+        await repository.trackEvent(TrackUserEvent(name: "persisted-event"))
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 1)
+
+        await repository.flushNow()
+
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 0)
+        let requests = await client.recordedRequests()
+        let request = try XCTUnwrap(requests.first)
+        XCTAssertEqual(request.httpMethod, "POST")
+        let payload = try XCTUnwrap(request.httpBody)
+        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: payload) as? [String: Any])
+        let events = try XCTUnwrap(body["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["name"] as? String, "persisted-event")
+    }
+
+    @MainActor
+    func testTrackingFlushRetainsFailedEventAndRetriesIt() async throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let client = TrackingHTTPClientSpy(response: .failure)
+        let repository = TrackRespositoryImpl(
+            config: Config(projectId: PROJECT_ID_FOR_TEST),
+            user: NubrickUser(),
+            persistentContainer: persistentContainer,
+            trackingHTTPClient: client
+        )
+
+        await repository.trackEvent(TrackUserEvent(name: "retry-event"))
+        await repository.flushNow()
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 1)
+
+        await client.setResponse(.statusCode(204))
+        await repository.flushNow()
+
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 0)
+        let requests = await client.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+    }
+
+    func testTrackingRetryPolicyRetriesTransientFailuresOnly() {
+        XCTAssertTrue(isRetryableTrackingStatusCode(500))
+        XCTAssertTrue(isRetryableTrackingStatusCode(503))
+        XCTAssertTrue(isRetryableTrackingStatusCode(429))
+        XCTAssertTrue(isRetryableTrackingStatusCode(408))
+        XCTAssertFalse(isRetryableTrackingStatusCode(400))
+        XCTAssertFalse(isRetryableTrackingStatusCode(401))
+        XCTAssertFalse(isRetryableTrackingStatusCode(404))
+        XCTAssertFalse(isRetryableTrackingStatusCode(413))
+        XCTAssertFalse(isRetryableTrackingStatusCode(422))
+    }
+
+    @MainActor
+    func testTrackingFlushDropsEventAfterNonRetryableHTTPResponse() async throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let client = TrackingHTTPClientSpy(response: .statusCode(400))
+        let repository = TrackRespositoryImpl(
+            config: Config(projectId: PROJECT_ID_FOR_TEST),
+            user: NubrickUser(),
+            persistentContainer: persistentContainer,
+            trackingHTTPClient: client
+        )
+
+        await repository.trackEvent(TrackUserEvent(name: "bad-event"))
+        await repository.flushNow()
+
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 0)
+        let requests = await client.recordedRequests()
+        XCTAssertEqual(requests.count, 1)
+    }
+
+    @MainActor
+    func testTrackingFlushRetainsEventAfterRetryableHTTPResponse() async throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let client = TrackingHTTPClientSpy(response: .statusCode(503))
+        let repository = TrackRespositoryImpl(
+            config: Config(projectId: PROJECT_ID_FOR_TEST),
+            user: NubrickUser(),
+            persistentContainer: persistentContainer,
+            trackingHTTPClient: client
+        )
+
+        await repository.trackEvent(TrackUserEvent(name: "retry-http-event"))
+        await repository.flushNow()
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 1)
+
+        await client.setResponse(.statusCode(200))
+        await repository.flushNow()
+
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 0)
+        let requests = await client.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+    }
+
+    @MainActor
+    func testTrackingFlushDropsBatchAfterNonRetryableHTTPResponseAndSendsLaterEvents() async throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let outbox = TrackOutbox(persistentContainer: persistentContainer)
+        let client = TrackingHTTPClientSpy(response: .statusCode(200))
+        await client.enqueueResponses([.statusCode(400)])
+        let repository = TrackRespositoryImpl(
+            config: Config(projectId: PROJECT_ID_FOR_TEST),
+            user: NubrickUser(),
+            persistentContainer: persistentContainer,
+            trackingHTTPClient: client
+        )
+        let first = makePendingTrackEvent(name: "poison-event")
+        let second = makePendingTrackEvent(name: "same-batch-event")
+
+        XCTAssertNotNil(outbox.insert(first, enqueuedAt: Date(timeIntervalSince1970: 1)))
+        XCTAssertNotNil(outbox.insert(second, enqueuedAt: Date(timeIntervalSince1970: 2)))
+
+        await repository.flushNow()
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 0)
+
+        await repository.trackEvent(TrackUserEvent(name: "later-event"))
+        await repository.flushNow()
+
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 0)
+        let requests = await client.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(try eventNames(in: requests[0]), ["poison-event", "same-batch-event"])
+        XCTAssertEqual(try eventNames(in: requests[1]), ["later-event"])
+    }
+
+    @MainActor
+    func testTrackingFlushNowWaitsForInFlightDrain() async throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let client = TrackingHTTPClientSpy(response: .statusCode(200), holdFetches: true)
+        let repository = TrackRespositoryImpl(
+            config: Config(projectId: PROJECT_ID_FOR_TEST),
+            user: NubrickUser(),
+            persistentContainer: persistentContainer,
+            trackingHTTPClient: client
+        )
+
+        await repository.trackEvent(TrackUserEvent(name: "held-event"))
+        let firstFlush = Task {
+            await repository.flushNow()
+        }
+        await client.waitForFetchStart()
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 1)
+
+        let secondFlushFinished = FlushCompletionFlag()
+        let secondFlush = Task {
+            await repository.flushNow()
+            await secondFlushFinished.markComplete()
+        }
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        let finishedWhileInFlight = await secondFlushFinished.isComplete()
+        XCTAssertFalse(
+            finishedWhileInFlight,
+            "flushNow returned while a drain was still in flight"
+        )
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 1)
+
+        await client.releaseHeldFetch()
+        await firstFlush.value
+        await secondFlush.value
+        let finishedAfterRelease = await secondFlushFinished.isComplete()
+        XCTAssertTrue(finishedAfterRelease)
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 0)
+        let requests = await client.recordedRequests()
+        XCTAssertEqual(requests.count, 1)
+    }
+
+    @MainActor
+    func testTrackingFlushSplitsAnOversizedEnvelopeWithoutDroppingEvents() async throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let outbox = TrackOutbox(persistentContainer: persistentContainer)
+        let client = TrackingHTTPClientSpy(response: .statusCode(200))
+        let repository = TrackRespositoryImpl(
+            config: Config(projectId: String(repeating: "p", count: 40_000)),
+            user: NubrickUser(),
+            persistentContainer: persistentContainer,
+            trackingHTTPClient: client
+        )
+        let first = makePendingTrackEvent(name: String(repeating: "a", count: 245_000))
+        let second = makePendingTrackEvent(name: String(repeating: "b", count: 245_000))
+
+        XCTAssertNotNil(outbox.insert(first, enqueuedAt: Date(timeIntervalSince1970: 1)))
+        XCTAssertNotNil(outbox.insert(second, enqueuedAt: Date(timeIntervalSince1970: 2)))
+
+        await repository.flushNow()
+
+        XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 0)
+        let requests = await client.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+        for request in requests {
+            let body = try XCTUnwrap(request.httpBody)
+            XCTAssertLessThanOrEqual(body.count, 512 * 1024)
+            let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual((json["events"] as? [[String: Any]])?.count, 1)
+        }
+    }
+
+    @MainActor
+    func testCoreDataMigratesStoreCreatedByPreviousSDKVersion() throws {
+        let storeURL = makeTemporaryStoreURL()
+        defer { removeSQLiteStore(at: storeURL) }
+
+        let legacyModel = NSManagedObjectModel()
+        legacyModel.entities = [
+            UserEventEntity.entityDescription(),
+            ExperimentHistoryEntity.entityDescription(),
+        ]
+        let legacyContainer = NSPersistentContainer(
+            name: "com.nativebrik.sdk",
+            managedObjectModel: legacyModel
+        )
+        let legacyDescription = NSPersistentStoreDescription(url: storeURL)
+        legacyDescription.shouldAddStoreAsynchronously = false
+        legacyContainer.persistentStoreDescriptions = [legacyDescription]
+
+        var legacyLoadError: Error?
+        legacyContainer.loadPersistentStores { _, error in
+            legacyLoadError = error
+        }
+        XCTAssertNil(legacyLoadError)
+
+        let legacyEvent = UserEventEntity(context: legacyContainer.viewContext)
+        legacyEvent.name = "event-created-by-old-sdk"
+        legacyEvent.timestamp = Date(timeIntervalSince1970: 0)
+        try legacyContainer.viewContext.save()
+        legacyContainer.viewContext.reset()
+        let legacyStore = try XCTUnwrap(legacyContainer.persistentStoreCoordinator.persistentStores.first)
+        try legacyContainer.persistentStoreCoordinator.remove(legacyStore)
+
+        let migratedContainer = try XCTUnwrap(
+            createNativebrikCoreDataHelper(storeURL: storeURL),
+            "Expected the current SDK to migrate the previous store"
+        )
+        let migratedContext = migratedContainer.viewContext
+
+        let legacyRequest = NSFetchRequest<UserEventEntity>(entityName: "NativebrikUserEvent")
+        let migratedEvents = try migratedContext.fetch(legacyRequest)
+        XCTAssertEqual(migratedEvents.map(\.name), ["event-created-by-old-sdk"])
+
+        let outboxEvent = PendingTrackEventEntity(context: migratedContext)
+        outboxEvent.eventID = UUID().uuidString
+        outboxEvent.payload = Data("{}".utf8)
+        outboxEvent.eventType = "event"
+        outboxEvent.byteCount = Int64(outboxEvent.payload.count)
+        outboxEvent.createdAt = Date()
+        try migratedContext.save()
+
+        let outboxRequest = NSFetchRequest<PendingTrackEventEntity>(entityName: "NativebrikPendingTrackEvent")
+        XCTAssertEqual(try migratedContext.count(for: outboxRequest), 1)
+        migratedContext.reset()
+        let migratedStore = try XCTUnwrap(migratedContainer.persistentStoreCoordinator.persistentStores.first)
+        try migratedContainer.persistentStoreCoordinator.remove(migratedStore)
+    }
+
+    @MainActor
+    private func pendingTrackEventCount(in persistentContainer: NSPersistentContainer) throws -> Int {
+        let request = NSFetchRequest<PendingTrackEventEntity>(entityName: "NativebrikPendingTrackEvent")
+        return try persistentContainer.viewContext.count(for: request)
+    }
+
+    @MainActor
+    private func pendingTrackEventIDs(in persistentContainer: NSPersistentContainer) throws -> [String] {
+        let request = NSFetchRequest<PendingTrackEventEntity>(entityName: "NativebrikPendingTrackEvent")
+        request.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: true)]
+        return try persistentContainer.viewContext.fetch(request).map(\.eventID)
+    }
+
+    private func eventNames(in request: URLRequest) throws -> [String] {
+        let payload = try XCTUnwrap(request.httpBody)
+        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: payload) as? [String: Any])
+        let events = try XCTUnwrap(body["events"] as? [[String: Any]])
+        return events.map { $0["name"] as? String ?? "" }
+    }
+
+    private func makePendingTrackEvent(name: String) -> TrackEvent {
+        TrackEvent(
+            typename: .Event,
+            experimentId: nil,
+            variantId: nil,
+            name: name,
+            timestamp: "2026-01-01T00:00:00Z",
+            exceptions: nil,
+            threads: nil,
+            platform: nil,
+            flutterSdkVersion: nil,
+            severity: nil,
+            eventUuid: UUID().uuidString
+        )
+    }
+
+    private func makeTemporaryStoreURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("sqlite")
+    }
+
+    private func removeSQLiteStore(at storeURL: URL) {
+        for suffix in ["", "-shm", "-wal"] {
+            try? FileManager.default.removeItem(atPath: storeURL.path + suffix)
+        }
+    }
+
+    @MainActor
+    private func closeAndRemovePersistentStore(
+        _ persistentContainer: NSPersistentContainer,
+        at storeURL: URL
+    ) {
+        persistentContainer.viewContext.reset()
+        for store in persistentContainer.persistentStoreCoordinator.persistentStores {
+            try? persistentContainer.persistentStoreCoordinator.remove(store)
+        }
+        removeSQLiteStore(at: storeURL)
+    }
+
     func testNubrickCauseDetectionOnlyConsidersCrashAttributedMetricKitThread() {
         let appFrame = StackFrame(binaryName: "Runner")
         let nubrickFrame = StackFrame(binaryName: "Nubrick")


### PR DESCRIPTION
## Summary

- Persist pending tracking events in a Core Data outbox.
- Batch and retry delivery, prioritizing crash events and flushing on app lifecycle changes.
- Add coverage for outbox retention, retry behavior, payload limits, and migration.

## Testing

- Not run (not requested).