### PR TITLE
fix: preserve tracking request context

### DIFF
--- a/Sources/Nubrick/Data/database/helper.swift
+++ b/Sources/Nubrick/Data/database/helper.swift
@@ -74,6 +74,8 @@ final class PendingTrackEventEntity: NSManagedObject {
     @NSManaged var eventType: String
     @NSManaged var byteCount: Int64
     @NSManaged var createdAt: Date
+    @NSManaged var userId: String?
+    @NSManaged var metaPayload: Data?
 
     static func entityDescription() -> NSEntityDescription {
         let entity = NSEntityDescription()
@@ -105,7 +107,17 @@ final class PendingTrackEventEntity: NSManagedObject {
         createdAt.attributeType = .dateAttributeType
         createdAt.isOptional = false
 
-        entity.properties = [eventID, payload, eventType, byteCount, createdAt]
+        let userId = NSAttributeDescription()
+        userId.name = "userId"
+        userId.attributeType = .stringAttributeType
+        userId.isOptional = true
+
+        let metaPayload = NSAttributeDescription()
+        metaPayload.name = "metaPayload"
+        metaPayload.attributeType = .binaryDataAttributeType
+        metaPayload.isOptional = true
+
+        entity.properties = [eventID, payload, eventType, byteCount, createdAt, userId, metaPayload]
         return entity
     }
 }

--- a/Sources/Nubrick/Data/track.swift
+++ b/Sources/Nubrick/Data/track.swift
@@ -151,17 +151,17 @@ public enum CrashSeverity: String, Sendable {
 }
 
 protocol TrackRepository2 : Actor {
-    func trackExperimentEvent(_ event: TrackExperimentEvent)
-    func trackEvent(_ event: TrackUserEvent)
+    func trackExperimentEvent(_ event: TrackExperimentEvent) async
+    func trackEvent(_ event: TrackUserEvent) async
     func flushNow() async
 
     func processMetricKitCrash(
         callStackTreeJSON: Data,
         terminationReason: String?,
         exceptionType: UInt32?
-    )
+    ) async
 
-    func sendFlutterCrash(_ crashEvent: TrackCrashEvent)
+    func sendFlutterCrash(_ crashEvent: TrackCrashEvent) async
     func sendSurveyResponse(experimentId: String, variantId: String, response_data: String) async
 }
 
@@ -231,7 +231,7 @@ func isNubrickCausedCrash(_ crashEvent: TrackCrashEvent) -> Bool {
     }
 }
 
-struct TrackEventMeta: Encodable {
+struct TrackEventMeta: Codable, Equatable {
     var appId: String?
     var appVersion: String?
     var cfBundleVersion: String?
@@ -291,6 +291,8 @@ struct PendingTrackEvent {
     let eventID: String
     let event: TrackEvent
     let payloadSize: Int
+    let userId: String?
+    let meta: TrackEventMeta?
 }
 
 struct TrackOutboxLimits: Sendable {
@@ -321,7 +323,12 @@ final class TrackOutbox {
         self.limits = limits
     }
 
-    func insert(_ event: TrackEvent, enqueuedAt: Date = getCurrentDate()) -> Int? {
+    func insert(
+        _ event: TrackEvent,
+        userId: String,
+        meta: TrackEventMeta,
+        enqueuedAt: Date = getCurrentDate()
+    ) -> Int? {
         guard let payload = try? JSONEncoder().encode(event) else {
             trackWarn("Dropping tracking event because it could not be persisted.")
             return nil
@@ -335,6 +342,7 @@ final class TrackOutbox {
         let limits = limits
         let eventID = event.eventUuid
         let eventType = event.typename
+        let metaPayload = try? JSONEncoder().encode(meta)
         return context.performAndWait {
             do {
                 try Self.enforceLimits(in: context, limits: limits, incomingByteCount: payload.count)
@@ -345,6 +353,8 @@ final class TrackOutbox {
                 entity.eventType = eventType.rawValue
                 entity.byteCount = Int64(payload.count)
                 entity.createdAt = enqueuedAt
+                entity.userId = userId
+                entity.metaPayload = metaPayload
                 try context.save()
 
                 guard eventType != .Crash else {
@@ -367,9 +377,13 @@ final class TrackOutbox {
 
     func nextNormalBatch(maxEvents: Int, maxPayloadBytes: Int) throws -> [PendingTrackEvent] {
         let entries = try fetch(excludingEventType: TrackEvent.Typename.Crash.rawValue, limit: maxEvents)
+        guard let first = entries.first else { return [] }
         var batch = [PendingTrackEvent]()
         var payloadBytes = 0
         for entry in entries {
+            if entry.userId != first.userId || entry.meta != first.meta {
+                break
+            }
             if !batch.isEmpty && payloadBytes + entry.payloadSize > maxPayloadBytes {
                 break
             }
@@ -427,10 +441,18 @@ final class TrackOutbox {
                         trackWarn("Dropping corrupt tracking event from the outbox.")
                         continue
                     }
+                    let meta: TrackEventMeta?
+                    if let metaPayload = entity.metaPayload {
+                        meta = try? JSONDecoder().decode(TrackEventMeta.self, from: metaPayload)
+                    } else {
+                        meta = nil
+                    }
                     pending.append(PendingTrackEvent(
                         eventID: entity.eventID,
                         event: event,
-                        payloadSize: Int(entity.byteCount)
+                        payloadSize: Int(entity.byteCount),
+                        userId: entity.userId,
+                        meta: meta
                     ))
                 }
                 if context.hasChanges {
@@ -528,8 +550,8 @@ actor TrackRespositoryImpl: TrackRepository2 {
         return request
     }
 
-    func trackExperimentEvent(_ event: TrackExperimentEvent) {
-        enqueue(TrackEvent(
+    func trackExperimentEvent(_ event: TrackExperimentEvent) async {
+        await enqueue(TrackEvent(
             typename: .Experiment,
             experimentId: event.experimentId,
             variantId: event.variantId,
@@ -538,8 +560,8 @@ actor TrackRespositoryImpl: TrackRepository2 {
         ))
     }
     
-    func trackEvent(_ event: TrackUserEvent) {
-        enqueue(TrackEvent(
+    func trackEvent(_ event: TrackUserEvent) async {
+        await enqueue(TrackEvent(
             typename: .Event,
             name: event.name,
             timestamp: getCurrentDate().ISO8601Format(),
@@ -554,8 +576,15 @@ actor TrackRespositoryImpl: TrackRepository2 {
         await drainOutbox()
     }
 
-    private func enqueue(_ event: TrackEvent) {
-        guard let pendingNormalEventCount = outbox.insert(event) else { return }
+    private func enqueue(_ event: TrackEvent) async {
+        let (userId, meta) = await MainActor.run {
+            (self.user.id, TrackEventMeta.current())
+        }
+        enqueue(event, userId: userId, meta: meta)
+    }
+
+    private func enqueue(_ event: TrackEvent, userId: String, meta: TrackEventMeta) {
+        guard let pendingNormalEventCount = outbox.insert(event, userId: userId, meta: meta) else { return }
         if event.typename == .Crash || pendingNormalEventCount >= maxBatchSize {
             requestFlush(after: 0)
         } else {
@@ -646,8 +675,11 @@ actor TrackRespositoryImpl: TrackRepository2 {
         guard !pending.isEmpty else { return true }
 
         do {
-            let userID = await MainActor.run { self.user.id }
-            let meta = await TrackEventMeta.current()
+            let (liveUserId, liveMeta) = await MainActor.run {
+                (self.user.id, TrackEventMeta.current())
+            }
+            let userID = pending[0].userId ?? liveUserId
+            let meta = pending[0].meta ?? liveMeta
             var batch = pending
 
             while !batch.isEmpty {
@@ -691,7 +723,7 @@ actor TrackRespositoryImpl: TrackRepository2 {
         callStackTreeJSON: Data,
         terminationReason: String?,
         exceptionType: UInt32?
-    ) {
+    ) async {
         if let callStackTree = try? JSONDecoder().decode(
             CallStackTree.self,
             from: callStackTreeJSON
@@ -752,11 +784,14 @@ actor TrackRespositoryImpl: TrackRepository2 {
                 threads: threads,
                 platform: "ios"
             )
-            sendCrashToBackend(crashEvent)
+            await sendCrashToBackend(crashEvent)
         }
     }
 
-    private func sendCrashToBackend(_ crashEvent: TrackCrashEvent) {
+    private func sendCrashToBackend(_ crashEvent: TrackCrashEvent) async {
+        let (userId, meta) = await MainActor.run {
+            (self.user.id, TrackEventMeta.current())
+        }
         let causedByNativebrik = isNubrickCausedCrash(crashEvent)
 
         // Only send error tracking events for error or fatal severity
@@ -767,7 +802,7 @@ actor TrackRespositoryImpl: TrackRepository2 {
                 timestamp: getCurrentDate().ISO8601Format(),
                 platform: nil,
                 eventUuid: UUID().uuidString
-            ))
+            ), userId: userId, meta: meta)
         }
         if causedByNativebrik {
             if crashEvent.severity.isErrorLevel {
@@ -777,7 +812,7 @@ actor TrackRespositoryImpl: TrackRepository2 {
                     timestamp: getCurrentDate().ISO8601Format(),
                     platform: nil,
                     eventUuid: UUID().uuidString
-                ))
+                ), userId: userId, meta: meta)
             }
             enqueue(TrackEvent(
                 typename: .Crash,
@@ -788,12 +823,12 @@ actor TrackRespositoryImpl: TrackRepository2 {
                 flutterSdkVersion: crashEvent.flutterSdkVersion,
                 severity: crashEvent.severity.rawValue,
                 eventUuid: UUID().uuidString
-            ))
+            ), userId: userId, meta: meta)
         }
     }
 
-    func sendFlutterCrash(_ crashEvent: TrackCrashEvent) {
-        sendCrashToBackend(crashEvent)
+    func sendFlutterCrash(_ crashEvent: TrackCrashEvent) async {
+        await sendCrashToBackend(crashEvent)
     }
 
     func sendSurveyResponse(experimentId: String, variantId: String, response_data: String) async {

--- a/Tests/NubrickTests/Data/repository.swift
+++ b/Tests/NubrickTests/Data/repository.swift
@@ -571,7 +571,13 @@ final class HttpRequestReposotiryTests: XCTestCase {
         }
         XCTAssertNil(previousLoadError)
 
-        let previousEvent = PendingTrackEventEntity(context: previousContainer.viewContext)
+        let previousOutboxEntity = try XCTUnwrap(
+            previousModel.entitiesByName["NativebrikPendingTrackEvent"]
+        )
+        let previousEvent = PendingTrackEventEntity(
+            entity: previousOutboxEntity,
+            insertInto: previousContainer.viewContext
+        )
         previousEvent.eventID = "legacy-event"
         previousEvent.payload = Data("{}".utf8)
         previousEvent.eventType = "event"
@@ -620,7 +626,13 @@ final class HttpRequestReposotiryTests: XCTestCase {
         }
         XCTAssertNil(legacyLoadError)
 
-        let legacyEvent = UserEventEntity(context: legacyContainer.viewContext)
+        let legacyUserEventEntity = try XCTUnwrap(
+            legacyModel.entitiesByName["NativebrikUserEvent"]
+        )
+        let legacyEvent = UserEventEntity(
+            entity: legacyUserEventEntity,
+            insertInto: legacyContainer.viewContext
+        )
         legacyEvent.name = "event-created-by-old-sdk"
         legacyEvent.timestamp = Date(timeIntervalSince1970: 0)
         try legacyContainer.viewContext.save()
@@ -638,7 +650,13 @@ final class HttpRequestReposotiryTests: XCTestCase {
         let migratedEvents = try migratedContext.fetch(legacyRequest)
         XCTAssertEqual(migratedEvents.map(\.name), ["event-created-by-old-sdk"])
 
-        let outboxEvent = PendingTrackEventEntity(context: migratedContext)
+        let migratedOutboxEntity = try XCTUnwrap(
+            migratedContainer.managedObjectModel.entitiesByName["NativebrikPendingTrackEvent"]
+        )
+        let outboxEvent = PendingTrackEventEntity(
+            entity: migratedOutboxEntity,
+            insertInto: migratedContext
+        )
         outboxEvent.eventID = UUID().uuidString
         outboxEvent.payload = Data("{}".utf8)
         outboxEvent.eventType = "event"

--- a/Tests/NubrickTests/Data/repository.swift
+++ b/Tests/NubrickTests/Data/repository.swift
@@ -23,9 +23,9 @@ private actor SurveyResponseTrackRepositorySpy: TrackRepository2 {
     private var responses: [Response] = []
     private var responseWaiters: [CheckedContinuation<Response, Never>] = []
 
-    func trackExperimentEvent(_ event: TrackExperimentEvent) {}
+    func trackExperimentEvent(_ event: TrackExperimentEvent) async {}
 
-    func trackEvent(_ event: TrackUserEvent) {}
+    func trackEvent(_ event: TrackUserEvent) async {}
 
     func flushNow() async {}
 
@@ -33,9 +33,9 @@ private actor SurveyResponseTrackRepositorySpy: TrackRepository2 {
         callStackTreeJSON: Data,
         terminationReason: String?,
         exceptionType: UInt32?
-    ) {}
+    ) async {}
 
-    func sendFlutterCrash(_ crashEvent: TrackCrashEvent) {}
+    func sendFlutterCrash(_ crashEvent: TrackCrashEvent) async {}
 
     func sendSurveyResponse(experimentId: String, variantId: String, response_data: String) async {
         let response = Response(
@@ -169,9 +169,9 @@ final class HttpRequestReposotiryTests: XCTestCase {
         let second = makePendingTrackEvent(name: "second")
         let third = makePendingTrackEvent(name: "third")
 
-        XCTAssertNotNil(outbox.insert(first, enqueuedAt: Date(timeIntervalSince1970: 1)))
-        XCTAssertNotNil(outbox.insert(second, enqueuedAt: Date(timeIntervalSince1970: 2)))
-        XCTAssertNotNil(outbox.insert(third, enqueuedAt: Date(timeIntervalSince1970: 3)))
+        XCTAssertNotNil(insertOutboxEvent(outbox, first, enqueuedAt: Date(timeIntervalSince1970: 1)))
+        XCTAssertNotNil(insertOutboxEvent(outbox, second, enqueuedAt: Date(timeIntervalSince1970: 2)))
+        XCTAssertNotNil(insertOutboxEvent(outbox, third, enqueuedAt: Date(timeIntervalSince1970: 3)))
 
         XCTAssertEqual(
             try pendingTrackEventIDs(in: persistentContainer),
@@ -195,8 +195,8 @@ final class HttpRequestReposotiryTests: XCTestCase {
             limits: TrackOutboxLimits(maxQueueSize: 10, maxQueueBytes: byteLimit)
         )
 
-        XCTAssertNotNil(outbox.insert(first, enqueuedAt: Date(timeIntervalSince1970: 1)))
-        XCTAssertNotNil(outbox.insert(second, enqueuedAt: Date(timeIntervalSince1970: 2)))
+        XCTAssertNotNil(insertOutboxEvent(outbox, first, enqueuedAt: Date(timeIntervalSince1970: 1)))
+        XCTAssertNotNil(insertOutboxEvent(outbox, second, enqueuedAt: Date(timeIntervalSince1970: 2)))
 
         XCTAssertEqual(try pendingTrackEventIDs(in: persistentContainer), [second.eventUuid])
     }
@@ -330,8 +330,8 @@ final class HttpRequestReposotiryTests: XCTestCase {
         let first = makePendingTrackEvent(name: "poison-event")
         let second = makePendingTrackEvent(name: "same-batch-event")
 
-        XCTAssertNotNil(outbox.insert(first, enqueuedAt: Date(timeIntervalSince1970: 1)))
-        XCTAssertNotNil(outbox.insert(second, enqueuedAt: Date(timeIntervalSince1970: 2)))
+        XCTAssertNotNil(insertOutboxEvent(outbox, first, enqueuedAt: Date(timeIntervalSince1970: 1)))
+        XCTAssertNotNil(insertOutboxEvent(outbox, second, enqueuedAt: Date(timeIntervalSince1970: 2)))
 
         await repository.flushNow()
         XCTAssertEqual(try pendingTrackEventCount(in: persistentContainer), 0)
@@ -406,8 +406,8 @@ final class HttpRequestReposotiryTests: XCTestCase {
         let first = makePendingTrackEvent(name: String(repeating: "a", count: 245_000))
         let second = makePendingTrackEvent(name: String(repeating: "b", count: 245_000))
 
-        XCTAssertNotNil(outbox.insert(first, enqueuedAt: Date(timeIntervalSince1970: 1)))
-        XCTAssertNotNil(outbox.insert(second, enqueuedAt: Date(timeIntervalSince1970: 2)))
+        XCTAssertNotNil(insertOutboxEvent(outbox, first, enqueuedAt: Date(timeIntervalSince1970: 1)))
+        XCTAssertNotNil(insertOutboxEvent(outbox, second, enqueuedAt: Date(timeIntervalSince1970: 2)))
 
         await repository.flushNow()
 
@@ -420,6 +420,180 @@ final class HttpRequestReposotiryTests: XCTestCase {
             let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
             XCTAssertEqual((json["events"] as? [[String: Any]])?.count, 1)
         }
+    }
+
+    @MainActor
+    func testTrackingFlushUsesUserIdAndMetaCapturedAtTrackTime() async throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let client = TrackingHTTPClientSpy(response: .statusCode(200))
+        let user = NubrickUser()
+        user.setProperty(BuiltinUserProperty.userId.rawValue, value: "user-before")
+        let repository = TrackRespositoryImpl(
+            config: Config(projectId: PROJECT_ID_FOR_TEST),
+            user: user,
+            persistentContainer: persistentContainer,
+            trackingHTTPClient: client
+        )
+
+        await repository.trackEvent(TrackUserEvent(name: "before-switch"))
+        user.setProperty(BuiltinUserProperty.userId.rawValue, value: "user-after")
+        await repository.flushNow()
+
+        let requests = await client.recordedRequests()
+        let body = try requestJSON(in: try XCTUnwrap(requests.first))
+        XCTAssertEqual(body["userId"] as? String, "user-before")
+        let meta = try XCTUnwrap(body["meta"] as? [String: Any])
+        XCTAssertEqual(meta["sdkVersion"] as? String, NubrickConstants.sdkVersion)
+        XCTAssertEqual(meta["platform"] as? String, "ios")
+    }
+
+    @MainActor
+    func testTrackingFlushSendsSeparateRequestsWhenCapturedUserIdChanges() async throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let client = TrackingHTTPClientSpy(response: .statusCode(200))
+        let user = NubrickUser()
+        user.setProperty(BuiltinUserProperty.userId.rawValue, value: "user-a")
+        let repository = TrackRespositoryImpl(
+            config: Config(projectId: PROJECT_ID_FOR_TEST),
+            user: user,
+            persistentContainer: persistentContainer,
+            trackingHTTPClient: client
+        )
+
+        await repository.trackEvent(TrackUserEvent(name: "event-a"))
+        user.setProperty(BuiltinUserProperty.userId.rawValue, value: "user-b")
+        await repository.trackEvent(TrackUserEvent(name: "event-b"))
+        await repository.flushNow()
+
+        let requests = await client.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(try requestJSON(in: requests[0])["userId"] as? String, "user-a")
+        XCTAssertEqual(try eventNames(in: requests[0]), ["event-a"])
+        XCTAssertEqual(try requestJSON(in: requests[1])["userId"] as? String, "user-b")
+        XCTAssertEqual(try eventNames(in: requests[1]), ["event-b"])
+    }
+
+    @MainActor
+    func testTrackingFlushSendsSeparateRequestsWhenCapturedMetaChanges() async throws {
+        let storeURL = makeTemporaryStoreURL()
+        let persistentContainer = try XCTUnwrap(createNativebrikCoreDataHelper(storeURL: storeURL))
+        defer { closeAndRemovePersistentStore(persistentContainer, at: storeURL) }
+        let outbox = TrackOutbox(persistentContainer: persistentContainer)
+        let client = TrackingHTTPClientSpy(response: .statusCode(200))
+        let repository = TrackRespositoryImpl(
+            config: Config(projectId: PROJECT_ID_FOR_TEST),
+            user: NubrickUser(),
+            persistentContainer: persistentContainer,
+            trackingHTTPClient: client
+        )
+        let firstMeta = TrackEventMeta(
+            appId: "app.one",
+            appVersion: "1.0.0",
+            cfBundleVersion: "1",
+            osName: "iOS",
+            osVersion: "18.0",
+            sdkVersion: "1.0.0"
+        )
+        let secondMeta = TrackEventMeta(
+            appId: "app.one",
+            appVersion: "2.0.0",
+            cfBundleVersion: "2",
+            osName: "iOS",
+            osVersion: "18.1",
+            sdkVersion: "1.1.0"
+        )
+
+        XCTAssertNotNil(insertOutboxEvent(
+            outbox,
+            makePendingTrackEvent(name: "old-app"),
+            userId: "same-user",
+            meta: firstMeta,
+            enqueuedAt: Date(timeIntervalSince1970: 1)
+        ))
+        XCTAssertNotNil(insertOutboxEvent(
+            outbox,
+            makePendingTrackEvent(name: "new-app"),
+            userId: "same-user",
+            meta: secondMeta,
+            enqueuedAt: Date(timeIntervalSince1970: 2)
+        ))
+
+        await repository.flushNow()
+
+        let requests = await client.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(try requestJSON(in: requests[0])["meta"] as? [String: String], [
+            "appId": "app.one",
+            "appVersion": "1.0.0",
+            "cfBundleVersion": "1",
+            "osName": "iOS",
+            "osVersion": "18.0",
+            "sdkVersion": "1.0.0",
+            "platform": "ios",
+        ])
+        XCTAssertEqual(try requestJSON(in: requests[1])["meta"] as? [String: String], [
+            "appId": "app.one",
+            "appVersion": "2.0.0",
+            "cfBundleVersion": "2",
+            "osName": "iOS",
+            "osVersion": "18.1",
+            "sdkVersion": "1.1.0",
+            "platform": "ios",
+        ])
+    }
+
+    @MainActor
+    func testCoreDataMigratesOutboxStoreWithoutCapturedRequestContext() throws {
+        let storeURL = makeTemporaryStoreURL()
+        defer { removeSQLiteStore(at: storeURL) }
+
+        let previousModel = NSManagedObjectModel()
+        previousModel.entities = [
+            UserEventEntity.entityDescription(),
+            ExperimentHistoryEntity.entityDescription(),
+            previousOutboxEntityDescription(),
+        ]
+        let previousContainer = NSPersistentContainer(
+            name: "com.nativebrik.sdk",
+            managedObjectModel: previousModel
+        )
+        let previousDescription = NSPersistentStoreDescription(url: storeURL)
+        previousDescription.shouldAddStoreAsynchronously = false
+        previousContainer.persistentStoreDescriptions = [previousDescription]
+
+        var previousLoadError: Error?
+        previousContainer.loadPersistentStores { _, error in
+            previousLoadError = error
+        }
+        XCTAssertNil(previousLoadError)
+
+        let previousEvent = PendingTrackEventEntity(context: previousContainer.viewContext)
+        previousEvent.eventID = "legacy-event"
+        previousEvent.payload = Data("{}".utf8)
+        previousEvent.eventType = "event"
+        previousEvent.byteCount = Int64(previousEvent.payload.count)
+        previousEvent.createdAt = Date(timeIntervalSince1970: 1)
+        try previousContainer.viewContext.save()
+        previousContainer.viewContext.reset()
+        let previousStore = try XCTUnwrap(previousContainer.persistentStoreCoordinator.persistentStores.first)
+        try previousContainer.persistentStoreCoordinator.remove(previousStore)
+
+        let migratedContainer = try XCTUnwrap(
+            createNativebrikCoreDataHelper(storeURL: storeURL),
+            "Expected the current SDK to migrate the previous outbox store"
+        )
+        let request = NSFetchRequest<PendingTrackEventEntity>(entityName: "NativebrikPendingTrackEvent")
+        let migratedEvents = try migratedContainer.viewContext.fetch(request)
+        XCTAssertEqual(migratedEvents.map(\.eventID), ["legacy-event"])
+        XCTAssertNil(migratedEvents.first?.userId)
+        XCTAssertNil(migratedEvents.first?.metaPayload)
+        migratedContainer.viewContext.reset()
+        let migratedStore = try XCTUnwrap(migratedContainer.persistentStoreCoordinator.persistentStores.first)
+        try migratedContainer.persistentStoreCoordinator.remove(migratedStore)
     }
 
     @MainActor
@@ -493,10 +667,64 @@ final class HttpRequestReposotiryTests: XCTestCase {
     }
 
     private func eventNames(in request: URLRequest) throws -> [String] {
-        let payload = try XCTUnwrap(request.httpBody)
-        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: payload) as? [String: Any])
-        let events = try XCTUnwrap(body["events"] as? [[String: Any]])
+        let events = try XCTUnwrap(requestJSON(in: request)["events"] as? [[String: Any]])
         return events.map { $0["name"] as? String ?? "" }
+    }
+
+    private func requestJSON(in request: URLRequest) throws -> [String: Any] {
+        let payload = try XCTUnwrap(request.httpBody)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: payload) as? [String: Any])
+    }
+
+    private func insertOutboxEvent(
+        _ outbox: TrackOutbox,
+        _ event: TrackEvent,
+        userId: String = "test-user",
+        meta: TrackEventMeta = TrackEventMeta(
+            appId: "test.app",
+            appVersion: "1.0.0",
+            cfBundleVersion: "1",
+            osName: "iOS",
+            osVersion: "18.0",
+            sdkVersion: "0.0.0"
+        ),
+        enqueuedAt: Date
+    ) -> Int? {
+        outbox.insert(event, userId: userId, meta: meta, enqueuedAt: enqueuedAt)
+    }
+
+    private func previousOutboxEntityDescription() -> NSEntityDescription {
+        let entity = NSEntityDescription()
+        entity.name = "NativebrikPendingTrackEvent"
+        entity.managedObjectClassName = NSStringFromClass(PendingTrackEventEntity.self)
+
+        let eventID = NSAttributeDescription()
+        eventID.name = "eventID"
+        eventID.attributeType = .stringAttributeType
+        eventID.isOptional = false
+
+        let payload = NSAttributeDescription()
+        payload.name = "payload"
+        payload.attributeType = .binaryDataAttributeType
+        payload.isOptional = false
+
+        let eventType = NSAttributeDescription()
+        eventType.name = "eventType"
+        eventType.attributeType = .stringAttributeType
+        eventType.isOptional = false
+
+        let byteCount = NSAttributeDescription()
+        byteCount.name = "byteCount"
+        byteCount.attributeType = .integer64AttributeType
+        byteCount.isOptional = false
+
+        let createdAt = NSAttributeDescription()
+        createdAt.name = "createdAt"
+        createdAt.attributeType = .dateAttributeType
+        createdAt.isOptional = false
+
+        entity.properties = [eventID, payload, eventType, byteCount, createdAt]
+        return entity
     }
 
     private func makePendingTrackEvent(name: String) -> TrackEvent {


### PR DESCRIPTION
## Summary

- Persist the user ID and SDK metadata with each queued tracking event.
- Send distinct requests when queued events have different captured contexts.
- Cover Core Data migration and captured-context delivery.

## Tests

- `xcodebuild test -workspace Nubrick.xcworkspace -scheme NubrickTests -destination "platform=iOS Simulator,id=BA5D3F76-A24D-4A62-94B7-CE5E87AE0663" -only-testing:NubrickTests/HttpRequestReposotiryTests -derivedDataPath /private/tmp/nubrick-review-derived`